### PR TITLE
Add-output-flag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,10 +27,19 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Get the tag name
+        id: get_tag_name
+        run: |
+          TAG_NAME=$(echo "${{ github.head_ref }}" | sed -e 's/release-//')
+          echo "tag_name=${TAG_NAME}" >> $GITHUB_ENV
+      - name: Create tag
+        run: |
+          git tag ${{ env.tag_name }}
+          git push origin ${{ env.tag_name }}
       - name: Create release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          tag_name: ${{ env.tag_name }}
+          release_name: ${{ env.tag_name }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,4 +1,4 @@
-name: sum_dirac_dfcoef-release-pull-request
+name: create-release-pull-request
 
 on:
   workflow_dispatch:
@@ -63,7 +63,6 @@ jobs:
           git checkout -b "${{ env.BRANCH_NAME }}"
           git add .
           git commit -m "Release ${{ env.PACKAGE_NAME }} ${{ env.NEW_VERSION }}"
-          git tag "${{ env.TAG_NAME }}"
           git push origin "${{ env.BRANCH_NAME }}"
           gh pr create --title "Release ${{ env.PACKAGE_NAME }} ${{ env.NEW_VERSION }}" --body "Release ${{ env.PACKAGE_NAME }} ${{ env.NEW_VERSION }}"
         env:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ pip install sum_dirac_dfcoef
 You can use this program with the following command!
 
 ```sh
+# Output to MOLECULE_NAME.out
 /path/to/sum_dirac_dfcoef -i DIRAC_OUPUT_FILE_PATH -m MOLECULE_NAME
+# Specify output file name with -o option
+/path/to/sum_dirac_dfcoef -i DIRAC_OUPUT_FILE_PATH -m MOLECULE_NAME -o OUTPUT_FILE_NAME
 ```
 
 (e.g.)
@@ -115,6 +118,9 @@ optional arguments (--input and --mol are required)
   (required) molecule specification. Write the molecular formula (e.g. Cu2O).  
   **DON'T write the rational formula (e.g. CH3OH)**
 
+-  -o OUTPUT, --output OUTPUT
+  Output file name. Default: (-m or --mol option value).out (e.g) --m H2O => print to H2O.out
+
 - -c, --compress
 
   Compress output. Display all coefficients on one line for each MO.  
@@ -129,6 +135,12 @@ optional arguments (--input and --mol are required)
 
   Set the decimal places. Default: 5  
   (e.g) --decimal=3 => print orbital with 3 decimal places (0.123, 2.456, ...). range: 1-15
+
+- -a, --all-write
+  Print all MOs(Positronic and Electronic).
+
+- -p, --positronic-write
+  Print only Positronic MOs.
 
 - --debug
 

--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ You can use this program with the following command!
 
 ```sh
 # Output to MOLECULE_NAME.out
-/path/to/sum_dirac_dfcoef -i DIRAC_OUPUT_FILE_PATH -m MOLECULE_NAME
+sum_dirac_dfcoef -i DIRAC_OUPUT_FILE_PATH -m MOLECULE_NAME
 # Specify output file name with -o option
-/path/to/sum_dirac_dfcoef -i DIRAC_OUPUT_FILE_PATH -m MOLECULE_NAME -o OUTPUT_FILE_NAME
+sum_dirac_dfcoef -i DIRAC_OUPUT_FILE_PATH -m MOLECULE_NAME -o OUTPUT_FILE_NAME
 ```
 
 (e.g.)
 
 ```sh
-./sum_dirac_dfcoef -i x2c_uo2_238.out -m UO2
+sum_dirac_dfcoef -i x2c_uo2_238.out -m UO2
 ```
 
 A part of x2c_uo2_238.out (DIRAC output file, ... represents an omission)

--- a/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py
+++ b/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py
@@ -151,7 +151,7 @@ def space_separated_parsing(line: str) -> "list[str]":
     return [word for word in words if word != ""]
 
 
-def parse_molecule_input(args: "argparse.Namespace", elements: "list[str]") -> Atoms:
+def parse_molecule_input(args: "argparse.Namespace") -> Atoms:
     """
     Parse the molecule input and return the Atoms object.
 
@@ -397,7 +397,7 @@ def main() -> None:
 
     args: "argparse.Namespace" = parse_args()
     dirac_file: str = get_dirac_filename(args)
-    atoms: Atoms = parse_molecule_input(args, elements)
+    atoms: Atoms = parse_molecule_input(args)
 
     data_all_electronic_mo: "list[Data_per_MO]" = []
     data_all_positronic_mo: "list[Data_per_MO]" = []

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -45,18 +45,15 @@ def test_sum_dirac_dfcoeff_compress(ref_filename: str, result_filename: str, inp
     result_filepath = os.path.join(test_path, "results", result_filename)
     input_filepath = os.path.join(test_path, "data", input_filename)
 
-    test_command = f"sum_dirac_dfcoef -m {mol} -i {input_filepath} {options}"
+    test_command = f"sum_dirac_dfcoef -m {mol} -i {input_filepath} -o {result_filepath} {options}"
     print(test_command)
-    with open(result_filepath, "w") as file_output:
-        process = subprocess.run(
-            test_command,
-            shell=True,
-            stdout=file_output,
-            encoding="utf-8",
-            stderr=file_output,
-        )
-        if process.returncode != 0:
-            sys.exit(f"{test_command} failed with return code {process.returncode}")
+    process = subprocess.run(
+        test_command,
+        shell=True,
+        encoding="utf-8",
+    )
+    if process.returncode != 0:
+        sys.exit(f"{test_command} failed with return code {process.returncode}")
 
     ref_file: "list[list[str]]" = [re.split(" +", line.rstrip("\n")) for line in list(filter(lambda val: val != "", open(ref_filepath, "r").read().splitlines()))]
     out_file: "list[list[str]]" = [re.split(" +", line.rstrip("\n")) for line in list(filter(lambda val: val != "", open(result_filepath, "r").read().splitlines()))]
@@ -108,18 +105,15 @@ def test_sum_dirac_dfcoeff(ref_filename: str, result_filename: str, input_filena
     result_filepath = os.path.join(test_path, "results", result_filename)
     input_filepath = os.path.join(test_path, "data", input_filename)
 
-    test_command = f"sum_dirac_dfcoef -m {mol} -i {input_filepath} {options}"
+    test_command = f"sum_dirac_dfcoef -m {mol} -i {input_filepath} -o {result_filepath} {options}"
     print(test_command)
-    with open(result_filepath, "w") as file_output:
-        process = subprocess.run(
-            test_command,
-            shell=True,
-            stdout=file_output,
-            encoding="utf-8",
-            stderr=file_output,
-        )
-        if process.returncode != 0:
-            sys.exit(f"{test_command} failed with return code {process.returncode}")
+    process = subprocess.run(
+        test_command,
+        shell=True,
+        encoding="utf-8",
+    )
+    if process.returncode != 0:
+        sys.exit(f"{test_command} failed with return code {process.returncode}")
 
     ref_file: "list[list[str]]" = [re.split(" +", line.rstrip("\n")) for line in list(filter(lambda val: val != "", open(ref_filepath, "r").read().splitlines()))]
     out_file: "list[list[str]]" = [re.split(" +", line.rstrip("\n")) for line in list(filter(lambda val: val != "", open(result_filepath, "r").read().splitlines()))]


### PR DESCRIPTION
- Add -o, --output option
  - This option is optional, if you don't specify this option, the name of output is (-m or --mol option).out
  (e.g.)
  ```bash
  sum_dirac_dfcoef -i H2_H2.out -m H2
  > output file name: H2.out
  ```