### PR TITLE
Asterisk electron number

### DIFF
--- a/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py
+++ b/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py
@@ -406,6 +406,7 @@ def main() -> None:
     start_vector_print: bool = False
     is_electronic: bool = False
     electron_number: int = 0
+    prev_electron_number: int = electron_number
     mo_energy: float = 0.0
     mo_sym_type: str = ""
     coefficients: Coefficients = Coefficients()
@@ -483,7 +484,11 @@ def main() -> None:
                     is_electronic = True
                 else:
                     raise Exception("Unknown MO type")
-                electron_number = int(words[-2][:-1].replace("no.", ""))
+                try:
+                    electron_number = int(words[-2][:-1].replace("no.", ""))
+                    prev_electron_number = electron_number
+                except ValueError:  # If *** is printed, we have no information about what number this MO is. Therefore, we assume that electron_number is the next number after prev_electron_number.
+                    electron_number = prev_electron_number + 1
                 mo_energy = float(words[-1])
                 continue
 

--- a/test/data/Ar_Ar.out
+++ b/test/data/Ar_Ar.out
@@ -12,9 +12,9 @@ DIRAC master    (relqc01) starts by allocating       64000000 r*8 words (   0.47
 DIRAC nodes 1 to 3 starts by allocating            64000000 r*8 words (   0.477 GB) of memory
 DIRAC master    (relqc01) to allocate at most      2147483648 r*8 words (  16.000 GB) of memory
 DIRAC nodes 1 to 3 to allocate at most           2147483648 r*8 words (  16.000 GB) of memory
- 
+
 Note: maximum allocatable memory for master+nodes can be set by -aw (MW)/-ag (GB) flags in pam
- 
+
  *******************************************************************************
  *                                                                             *
  *                                O U T P U T                                  *
@@ -189,10 +189,10 @@ Note: maximum allocatable memory for master+nodes can be set by -aw (MW)/-ag (GB
 Version information
 -------------------
 
-Branch        | 
-Commit hash   | 
-Commit author | 
-Commit date   | 
+Branch        |
+Commit hash   |
+Commit author |
+Commit date   |
 
 
 Configuration and build information
@@ -205,7 +205,7 @@ CMake version            | 3.21.3
 CMake generator          | Unix Makefiles
 CMake build type         | release
 Configuration time       | 2021-11-08 16:17:02.823538
-Python version           | 
+Python version           |
 Fortran compiler         | /home/noda/Software/DIRAC/21.1/openmpi310_i8/bin/mpif90
 Fortran compiler version | 19.0
 Fortran compiler flags   |  -xHost -I/home/noda/Software/DIRAC/21.1/openmpi310_i8/lib -w -assume byterecl -g -traceback -DVAR_IFORT  -qopenmp -i8
@@ -242,66 +242,66 @@ Exatensor configuration  | unknown
 Execution time and host
 -----------------------
 
- 
+
      Date and time (Linux)  : Wed Nov  9 13:20:51 2022
-     Host name              : relqc01                                 
+     Host name              : relqc01
 
 
 Contents of the input file
 --------------------------
 
-**DIRAC                                                                                             
-.TITLE                                                                                              
-Ar                                                                                                  
-.WAVE FUNCTION                                                                                      
-.ANALYZE                                                                                            
-.PROPERTIES                                                                                         
-**INTEGRALS                                                                                         
-.NUCMOD                                                                                             
-1                                                                                                   
-*READIN                                                                                             
-.UNCONTRACT                                                                                         
-**HAMILTONIAN                                                                                       
-.X2C                                                                                                
-**WAVE FUNCTIONS                                                                                    
-.SCF                                                                                                
-.RELCCSD                                                                                            
-*SCF                                                                                                
-.MAXITR                                                                                             
- 100                                                                                                
-.EVCCNV                                                                                             
- 1.0E-10                                                                                            
-.ERGCNV                                                                                             
- 1.0E-10                                                                                            
-**ANALYZE                                                                                           
-.MULPOP                                                                                             
-.PRIVEC                                                                                             
-*PRIVEC                                                                                             
-.VECPRI                                                                                             
-all                                                                                                 
-all                                                                                                 
-**PROPERTIES                                                                                        
-.RHONUC                                                                                             
-**GENERAL                                                                                           
-.PCMOUT                                                                                             
-**MOLTRA                                                                                            
-.ACTIVE                                                                                             
-all                                                                                                 
-**MOLECULE                                                                                          
-*BASIS                                                                                              
-.DEFAULT                                                                                            
- dyall.3zp                                                                                          
-*END OF                                                                                             
+**DIRAC
+.TITLE
+Ar
+.WAVE FUNCTION
+.ANALYZE
+.PROPERTIES
+**INTEGRALS
+.NUCMOD
+1
+*READIN
+.UNCONTRACT
+**HAMILTONIAN
+.X2C
+**WAVE FUNCTIONS
+.SCF
+.RELCCSD
+*SCF
+.MAXITR
+ 100
+.EVCCNV
+ 1.0E-10
+.ERGCNV
+ 1.0E-10
+**ANALYZE
+.MULPOP
+.PRIVEC
+*PRIVEC
+.VECPRI
+all
+all
+**PROPERTIES
+.RHONUC
+**GENERAL
+.PCMOUT
+**MOLTRA
+.ACTIVE
+all
+**MOLECULE
+*BASIS
+.DEFAULT
+ dyall.3zp
+*END OF
 
 
 Contents of the molecule file
 -----------------------------
 
-1                                                                                                   
-                                                                                                    
-Ar      0.0000000000        0.0000000000        0.0000000000                                        
-                                                                                                    
-                                                                                                    
+1
+
+Ar      0.0000000000        0.0000000000        0.0000000000
+
+
 
 
     **************************************************************************
@@ -320,14 +320,14 @@ Ar      0.0000000000        0.0000000000        0.0000000000
 
  The 2018 CODATA Recommended Values of the Fundamental Physical Constants (Web V
  ersion 8.1)
-        Eite Tiesinga, Peter J. Mohr, David B. Newell, and Barry N. Taylor      
-            
-        Database developed by J. Baker, M. Douma, and S. Kotochigova            
-            
-  Available at http://physics.nist.gov/constants                                
-            
-  National Institute of Standards and Technology, Gaithersburg, MD 20899        
-            
+        Eite Tiesinga, Peter J. Mohr, David B. Newell, and Barry N. Taylor
+
+        Database developed by J. Baker, M. Douma, and S. Kotochigova
+
+  Available at http://physics.nist.gov/constants
+
+  National Institute of Standards and Technology, Gaithersburg, MD 20899
+
  * The speed of light :        137.0359992
  * Running in two-component mode
  * Parallel run with 3 slaves.
@@ -377,9 +377,9 @@ Ar      0.0000000000        0.0000000000        0.0000000000
 
  Symmetry test threshold:  5.00E-06
 
- Symmetry point group found: D(oo,h)        
+ Symmetry point group found: D(oo,h)
 
- The following symmetry elements were found: X  Y  Z  
+ The following symmetry elements were found: X  Y  Z
 
 
   Symmetry Operations
@@ -392,7 +392,7 @@ Ar      0.0000000000        0.0000000000        0.0000000000
                           SYMGRP:Point group information
                           ------------------------------
 
-Full group is:  D(oo,h)        
+Full group is:  D(oo,h)
 Represented as: D2h
 
    * The point group was generated by:
@@ -408,11 +408,11 @@ Represented as: D2h
      E  |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
     C2z | C2z   E   C2x  C2y  Oxy   i   Oyz  Oxz
     C2y | C2y  C2x   E   C2z  Oxz  Oyz   i   Oxy
-    C2x | C2x  C2y  C2z   E   Oyz  Oxz  Oxy   i 
+    C2x | C2x  C2y  C2z   E   Oyz  Oxz  Oxy   i
      i  |  i   Oxy  Oxz  Oyz   E   C2z  C2y  C2x
     Oxy | Oxy   i   Oyz  Oxz  C2z   E   C2x  C2y
     Oxz | Oxz  Oyz   i   Oxy  C2y  C2x   E   C2z
-    Oyz | Oyz  Oxz  Oxy   i   C2x  C2y  C2z   E 
+    Oyz | Oyz  Oxz  Oxy   i   C2x  C2y  C2z   E
 
    * Character table
 
@@ -429,16 +429,16 @@ Represented as: D2h
 
    * Direct product table
 
-        | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au 
+        | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au
    -----+----------------------------------------
-    Ag  | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au 
+    Ag  | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au
     B3u | B3u  Ag   B1g  B2u  B2g  B1u  Au   B3g
     B2u | B2u  B1g  Ag   B3u  B3g  Au   B1u  B2g
     B1g | B1g  B2u  B3u  Ag   Au   B3g  B2g  B1u
     B1u | B1u  B2g  B3g  Au   Ag   B3u  B2u  B1g
     B2g | B2g  B1u  Au   B3g  B3u  Ag   B1g  B2u
     B3g | B3g  Au   B1u  B2g  B2u  B1g  Ag   B3u
-    Au  | Au   B3g  B2g  B1u  B1g  B2u  B3u  Ag 
+    Au  | Au   B3g  B2g  B1u  B1g  B2u  B3u  Ag
 
 
                             **************************
@@ -489,9 +489,9 @@ Represented as: D2h
   Number of atom types :    1
   Total number of atoms:    1
 
-  label    atoms   charge   prim    cont     basis   
+  label    atoms   charge   prim    cont     basis
   ----------------------------------------------------------------------
-  Ar          1      18      69      69      L  - [18s11p3d|18s11p3d]                                            
+  Ar          1      18      69      69      L  - [18s11p3d|18s11p3d]
   ----------------------------------------------------------------------
                              69      69      L  - large components
   ----------------------------------------------------------------------
@@ -505,16 +505,16 @@ Represented as: D2h
   -----------------------------
 
   Atom type   1
-   1s-3s: K.G. Dyall, Theor. Chem. Acc. (2016) 135:128.                           
-   4s-7s: K.G. Dyall, J. Phys. Chem. A. (2009) 113:12638.                         
-   2p-3p: K.G. Dyall, Theor. Chem. Acc. (2016) 135:128.                           
-   4p-6p: K.G. Dyall, Theor. Chem. Acc. (2002) 108:335;                           
-          revision K.G. Dyall, Theor. Chem. Acc. (2006) 115:441.                  
-      7p: K.G. Dyall, Theor. Chem. Acc. (2012) 131:1172.                          
-      3d: K.G. Dyall and A.S.P. Gomes, unpublished.                               
-      4d: K.G. Dyall, Theor. Chem. Acc. (2007) 117:483.                           
-      5d: K.G. Dyall, Theor. Chem. Acc. (2004) 112:403;                           
-          revision  K.G. Dyall and A.S.P. Gomes, Theor. Chem. Acc. (2009) 125:97. 
+   1s-3s: K.G. Dyall, Theor. Chem. Acc. (2016) 135:128.
+   4s-7s: K.G. Dyall, J. Phys. Chem. A. (2009) 113:12638.
+   2p-3p: K.G. Dyall, Theor. Chem. Acc. (2016) 135:128.
+   4p-6p: K.G. Dyall, Theor. Chem. Acc. (2002) 108:335;
+          revision K.G. Dyall, Theor. Chem. Acc. (2006) 115:441.
+      7p: K.G. Dyall, Theor. Chem. Acc. (2012) 131:1172.
+      3d: K.G. Dyall and A.S.P. Gomes, unpublished.
+      4d: K.G. Dyall, Theor. Chem. Acc. (2007) 117:483.
+      5d: K.G. Dyall, Theor. Chem. Acc. (2004) 112:403;
+          revision  K.G. Dyall and A.S.P. Gomes, Theor. Chem. Acc. (2009) 125:97.
 
 
   Cartesian Coordinates (bohr)
@@ -533,7 +533,7 @@ Represented as: D2h
   ----------------------------------------------
 
     1
- 
+
 Ar     0.0000000000   0.0000000000   0.0000000000
 
 
@@ -572,8 +572,8 @@ Ar     0.0000000000   0.0000000000   0.0000000000
                                 -----------------
 
    * Large components:   10
-     1  L Ar  1 s        2  L Ar  1 px       3  L Ar  1 py       4  L Ar  1 pz       5  L Ar  1 dxx      6  L Ar  1 dxy 
-     7  L Ar  1 dxz      8  L Ar  1 dyy      9  L Ar  1 dyz     10  L Ar  1 dzz 
+     1  L Ar  1 s        2  L Ar  1 px       3  L Ar  1 py       4  L Ar  1 pz       5  L Ar  1 dxx      6  L Ar  1 dxy
+     7  L Ar  1 dxz      8  L Ar  1 dyy      9  L Ar  1 dyz     10  L Ar  1 dzz
    * Small components:    0
 
 
@@ -582,8 +582,8 @@ Ar     0.0000000000   0.0000000000   0.0000000000
                                 -----------------
 
    * Large components:   10
-     1  L Ag Ar s        2  L Ag Ar dxx      3  L Ag Ar dyy      4  L Ag Ar dzz      5  L B3uAr px       6  L B2uAr py  
-     7  L B1gAr dxy      8  L B1uAr pz       9  L B2gAr dxz     10  L B3gAr dyz 
+     1  L Ag Ar s        2  L Ag Ar dxx      3  L Ag Ar dyy      4  L Ag Ar dzz      5  L B3uAr px       6  L B2uAr py
+     7  L B1gAr dxy      8  L B1uAr pz       9  L B2gAr dxz     10  L B3gAr dyz
    * Small components:    0
 
 
@@ -599,34 +599,34 @@ Ar     0.0000000000   0.0000000000   0.0000000000
 
   Symmetry  Ag ( 1)
 
-       18 functions:    Ar s   
-        3 functions:    Ar dxx 
-        3 functions:    Ar dyy 
-        3 functions:    Ar dzz 
+       18 functions:    Ar s
+        3 functions:    Ar dxx
+        3 functions:    Ar dyy
+        3 functions:    Ar dzz
 
   Symmetry  B3u( 2)
 
-       11 functions:    Ar px  
+       11 functions:    Ar px
 
   Symmetry  B2u( 3)
 
-       11 functions:    Ar py  
+       11 functions:    Ar py
 
   Symmetry  B1g( 4)
 
-        3 functions:    Ar dxy 
+        3 functions:    Ar dxy
 
   Symmetry  B1u( 5)
 
-       11 functions:    Ar pz  
+       11 functions:    Ar pz
 
   Symmetry  B2g( 6)
 
-        3 functions:    Ar dxz 
+        3 functions:    Ar dxz
 
   Symmetry  B3g( 7)
 
-        3 functions:    Ar dyz 
+        3 functions:    Ar dyz
 
 
    ***************************************************************************
@@ -641,10 +641,10 @@ Ar     0.0000000000   0.0000000000   0.0000000000
   - BSS with properties !
  * Print level:    0
  * Exact-Two-Component (X2C) Hamiltonian
-   Reference: 
+   Reference:
     M. Ilias and T. Saue:
-    "Implementation of an infinite-order two-component relativistic Hamiltonian 
-    by a simple one-step transformation." 
+    "Implementation of an infinite-order two-component relativistic Hamiltonian
+    by a simple one-step transformation."
     J. Chem. Phys., 126 (2007) 064102.
    additional reference for the new X2C module:
     S. Knecht and T. Saue:
@@ -673,8 +673,8 @@ Ar     0.0000000000   0.0000000000   0.0000000000
     **************************************************************************
 
  Wave function types requested (in input order):
-     HF        
-     RELCCSD   
+     HF
+     RELCCSD
 
  Wave function jobs in execution order (expanded):
  * Hartree-Fock calculation
@@ -707,7 +707,7 @@ Ar     0.0000000000   0.0000000000   0.0000000000
  * DIIS (in MO basis)
  * DIIS will be activated when convergence reaches : 1.00D+20
    - Maximum size of B-matrix:   10
- * Damping of Fock matrix when DIIS is not activated. 
+ * Damping of Fock matrix when DIIS is not activated.
    Weight of old matrix    : 0.250
  * Maximum number of SCF iterations  :  100
  * No quadratic convergent Hartree-Fock
@@ -735,8 +735,8 @@ Ar     0.0000000000   0.0000000000   0.0000000000
 ===========================================================================
  * Coefficients written in SO-basis
  * Vector print:
-    - Orbitals in fermion ircop E1g :all                                                                     
-    - Orbitals in fermion ircop E1u :all                                                                     
+    - Orbitals in fermion ircop E1g :all
+    - Orbitals in fermion ircop E1u :all
  * Only large component coefficients written out.
 ===========================================================================
  POPINP: Mulliken population analysis
@@ -756,7 +756,7 @@ Ar     0.0000000000   0.0000000000   0.0000000000
  * Print level:   0
  * Input label: **PROPE
  * Properties calculated for the following wave functions:
-     1: DHF 
+     1: DHF
  These initial settings of center and origins might be changed later:
  * Operator center (a.u.):      0.0000000000      0.0000000000      0.0000000000
  * Gauge origin    (a.u.):      0.0000000000      0.0000000000      0.0000000000
@@ -773,17 +773,17 @@ Ar     0.0000000000   0.0000000000   0.0000000000
     1  XDIPLEN              B3u     T+
 ...........................................................................
       Operator type DIAGONAL : scalar operator
-      Labels and factors     : XDIPLEN  +00+     1.0000000000000 (real)     
+      Labels and factors     : XDIPLEN  +00+     1.0000000000000 (real)
 ...........................................................................
     2  YDIPLEN              B2u     T+
 ...........................................................................
       Operator type DIAGONAL : scalar operator
-      Labels and factors     : YDIPLEN  +00+     1.0000000000000 (real)     
+      Labels and factors     : YDIPLEN  +00+     1.0000000000000 (real)
 ...........................................................................
     3  ZDIPLEN              B1u     T+
 ...........................................................................
       Operator type DIAGONAL : scalar operator
-      Labels and factors     : ZDIPLEN  +00+     1.0000000000000 (real)     
+      Labels and factors     : ZDIPLEN  +00+     1.0000000000000 (real)
 ...........................................................................
 ---------------------------------------------------------------------------
 
@@ -797,20 +797,20 @@ Ar     0.0000000000   0.0000000000   0.0000000000
  * Electronic orbitals only.
  * Total active space.
     Fermion ircop:E1g
-    all                                                                     
+    all
     Fermion ircop:E1u
-    all                                                                     
+    all
 
  * Set-up for 2-index transformation
  * LS Integrals not included in core Fock-matrix
  * SS Integrals not included in core Fock-matrix
  * Active spaces:
     Fermion ircop:E1g
-    - Index  1:  all                                                                     
-    - Index  2:  all                                                                     
+    - Index  1:  all
+    - Index  2:  all
     Fermion ircop:E1u
-    - Index  1:  all                                                                     
-    - Index  2:  all                                                                     
+    - Index  1:  all
+    - Index  2:  all
 
  * Set-up for 4-index transformation
  * Following scheme      :   6
@@ -823,15 +823,15 @@ Ar     0.0000000000   0.0000000000   0.0000000000
  * Gaunt Integrals not transformed.
  * Active spaces:
     Fermion ircop:E1g
-    - Index  1:  all                                                                     
-    - Index  2:  all                                                                     
-    - Index  3:  all                                                                     
-    - Index  4:  all                                                                     
+    - Index  1:  all
+    - Index  2:  all
+    - Index  3:  all
+    - Index  4:  all
     Fermion ircop:E1u
-    - Index  1:  all                                                                     
-    - Index  2:  all                                                                     
-    - Index  3:  all                                                                     
-    - Index  4:  all                                                                     
+    - Index  1:  all
+    - Index  2:  all
+    - Index  3:  all
+    - Index  4:  all
 
 
  ********************************************************************************
@@ -857,9 +857,9 @@ Ar     0.0000000000   0.0000000000   0.0000000000
 
  Symmetry test threshold:  5.00E-06
 
- Symmetry point group found: D(oo,h)        
+ Symmetry point group found: D(oo,h)
 
- The following symmetry elements were found: X  Y  Z  
+ The following symmetry elements were found: X  Y  Z
 
 
   Symmetry Operations
@@ -872,7 +872,7 @@ Ar     0.0000000000   0.0000000000   0.0000000000
                           SYMGRP:Point group information
                           ------------------------------
 
-Full group is:  D(oo,h)        
+Full group is:  D(oo,h)
 Represented as: D2h
 
    * The point group was generated by:
@@ -888,11 +888,11 @@ Represented as: D2h
      E  |  E   C2z  C2y  C2x   i   Oxy  Oxz  Oyz
     C2z | C2z   E   C2x  C2y  Oxy   i   Oyz  Oxz
     C2y | C2y  C2x   E   C2z  Oxz  Oyz   i   Oxy
-    C2x | C2x  C2y  C2z   E   Oyz  Oxz  Oxy   i 
+    C2x | C2x  C2y  C2z   E   Oyz  Oxz  Oxy   i
      i  |  i   Oxy  Oxz  Oyz   E   C2z  C2y  C2x
     Oxy | Oxy   i   Oyz  Oxz  C2z   E   C2x  C2y
     Oxz | Oxz  Oyz   i   Oxy  C2y  C2x   E   C2z
-    Oyz | Oyz  Oxz  Oxy   i   C2x  C2y  C2z   E 
+    Oyz | Oyz  Oxz  Oxy   i   C2x  C2y  C2z   E
 
    * Character table
 
@@ -909,16 +909,16 @@ Represented as: D2h
 
    * Direct product table
 
-        | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au 
+        | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au
    -----+----------------------------------------
-    Ag  | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au 
+    Ag  | Ag   B3u  B2u  B1g  B1u  B2g  B3g  Au
     B3u | B3u  Ag   B1g  B2u  B2g  B1u  Au   B3g
     B2u | B2u  B1g  Ag   B3u  B3g  Au   B1u  B2g
     B1g | B1g  B2u  B3u  Ag   Au   B3g  B2g  B1u
     B1u | B1u  B2g  B3g  Au   Ag   B3u  B2u  B1g
     B2g | B2g  B1u  Au   B3g  B3u  Ag   B1g  B2u
     B3g | B3g  Au   B1u  B2g  B2u  B1g  Ag   B3u
-    Au  | Au   B3g  B2g  B1u  B1g  B2u  B3u  Ag 
+    Au  | Au   B3g  B2g  B1u  B1g  B2u  B3u  Ag
 
 
                             **************************
@@ -969,9 +969,9 @@ Represented as: D2h
   Number of atom types :    1
   Total number of atoms:    1
 
-  label    atoms   charge   prim    cont     basis   
+  label    atoms   charge   prim    cont     basis
   ----------------------------------------------------------------------
-  Ar          1      18      69      69      L  - [18s11p3d|18s11p3d]                                            
+  Ar          1      18      69      69      L  - [18s11p3d|18s11p3d]
   ----------------------------------------------------------------------
                              69      69      L  - large components
                             170     170      S  - small components
@@ -986,16 +986,16 @@ Represented as: D2h
   -----------------------------
 
   Atom type   1
-   1s-3s: K.G. Dyall, Theor. Chem. Acc. (2016) 135:128.                           
-   4s-7s: K.G. Dyall, J. Phys. Chem. A. (2009) 113:12638.                         
-   2p-3p: K.G. Dyall, Theor. Chem. Acc. (2016) 135:128.                           
-   4p-6p: K.G. Dyall, Theor. Chem. Acc. (2002) 108:335;                           
-          revision K.G. Dyall, Theor. Chem. Acc. (2006) 115:441.                  
-      7p: K.G. Dyall, Theor. Chem. Acc. (2012) 131:1172.                          
-      3d: K.G. Dyall and A.S.P. Gomes, unpublished.                               
-      4d: K.G. Dyall, Theor. Chem. Acc. (2007) 117:483.                           
-      5d: K.G. Dyall, Theor. Chem. Acc. (2004) 112:403;                           
-          revision  K.G. Dyall and A.S.P. Gomes, Theor. Chem. Acc. (2009) 125:97. 
+   1s-3s: K.G. Dyall, Theor. Chem. Acc. (2016) 135:128.
+   4s-7s: K.G. Dyall, J. Phys. Chem. A. (2009) 113:12638.
+   2p-3p: K.G. Dyall, Theor. Chem. Acc. (2016) 135:128.
+   4p-6p: K.G. Dyall, Theor. Chem. Acc. (2002) 108:335;
+          revision K.G. Dyall, Theor. Chem. Acc. (2006) 115:441.
+      7p: K.G. Dyall, Theor. Chem. Acc. (2012) 131:1172.
+      3d: K.G. Dyall and A.S.P. Gomes, unpublished.
+      4d: K.G. Dyall, Theor. Chem. Acc. (2007) 117:483.
+      5d: K.G. Dyall, Theor. Chem. Acc. (2004) 112:403;
+          revision  K.G. Dyall and A.S.P. Gomes, Theor. Chem. Acc. (2009) 125:97.
 
 
   Cartesian Coordinates (bohr)
@@ -1014,7 +1014,7 @@ Represented as: D2h
   ----------------------------------------------
 
     1
- 
+
 Ar     0.0000000000   0.0000000000   0.0000000000
 
 
@@ -1098,7 +1098,7 @@ Total time used in ONEGEN (CPU)  0.02059300s and (WALL)  0.05756783s
                    *********************************************************************
 
 
-                   *** chosen path in X2C module: molecular X2C (with spin-orbit contributions)      
+                   *** chosen path in X2C module: molecular X2C (with spin-orbit contributions)
 
 
                                 Output from MODHAM
@@ -1117,16 +1117,16 @@ Total time used in ONEGEN (CPU)  0.02059300s and (WALL)  0.05756783s
   *** calculate AMFI for atom type 1 with atomic charge    18
   *** number of nuclei with identical atom type:   1
    unique nuclei index: 1
-  *** file with AMFI integrals for this center: AOPROPER_MNF.18.1   
+  *** file with AMFI integrals for this center: AOPROPER_MNF.18.1
 
 
                          ATOMIC NO-PAIR SO-MF CODE starts
                          --------------------------------
 
-   Douglas-Kroll type operators 
+   Douglas-Kroll type operators
   charge on the calculated atom:  0
   Mean-field summation for electrons #:  18
-    ...electronic occupation of Ar: [Ne]3s^2 3p^6             
+    ...electronic occupation of Ar: [Ne]3s^2 3p^6
  ****  Written to the file TOSCF for "relscf" ****
         charge: 18.000
       nprimit:  18 11  3  0
@@ -1195,9 +1195,9 @@ Total time used in ONEGEN (CPU)  0.02059300s and (WALL)  0.05756783s
 
  Symmetry test threshold:  5.00E-06
 
- Symmetry point group found: D(oo,h)        
+ Symmetry point group found: D(oo,h)
 
- The following symmetry elements were found: X  Y  Z  
+ The following symmetry elements were found: X  Y  Z
 
 
                       Nuclear contribution to dipole moments
@@ -1388,7 +1388,7 @@ It.    7    -528.6333210417      5.61D-09  2.58D-05  1.52D-05   DIIS   6    0.02
 It.    8    -528.6333210417      4.38D-11 -7.23D-06  2.03D-06   DIIS   6    0.02306318s   LL             Wed Nov  9
 --------------------------------------------------------------------------------------------------------------------------------
 * Convergence after    8 iterations.
-* Average elapsed time per iteration: 
+* Average elapsed time per iteration:
       No 2-ints    :    0.00823784s
       LL           :    0.05739474s
 
@@ -1479,13 +1479,13 @@ It.    8    -528.6333210417      4.38D-11 -7.23D-06  2.03D-06   DIIS   6    0.02
   Mj  1/2   1/2  -3/2   1/2  -3/2   1/2   1/2   1/2  -3/2
 
 * Occupation of subblocks
-                       E1g:  s 1/2 d 3/2 d 3/2 d 5/2 d 5/2 d 5/2                                                            
-                        Mj:    1/2   1/2  -3/2   1/2  -3/2   5/2                                                            
+                       E1g:  s 1/2 d 3/2 d 3/2 d 5/2 d 5/2 d 5/2
+                        Mj:    1/2   1/2  -3/2   1/2  -3/2   5/2
   closed shells (f=1.0000):     3     0     0     0     0     0
  virtual shells (f=0.0000):    15     3     3     3     3     3
 tot.num. of pos.erg shells:    18     3     3     3     3     3
-                       E1u:  p 1/2 p 3/2 p 3/2                                                                              
-                        Mj:    1/2   1/2  -3/2                                                                              
+                       E1u:  p 1/2 p 3/2 p 3/2
+                        Mj:    1/2   1/2  -3/2
   closed shells (f=1.0000):     2     2     2
  virtual shells (f=0.0000):     9     9     9
 tot.num. of pos.erg shells:    11    11    11
@@ -2022,7 +2022,7 @@ tot.num. of pos.erg shells:    11    11    11
       35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
       36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
 
-* Electronic eigenvalue no. 14:  2.4717998156571
+* Electronic eigenvalue no.***:  2.4717998156571
 ====================================================
        1  L Ag Ar s      -0.0000000000  0.0000000000  0.0000000000  0.0000000000
        2  L Ag Ar s       0.0000000000  0.0000000000  0.0000000000  0.0000000000
@@ -2763,7 +2763,7 @@ tot.num. of pos.erg shells:    11    11    11
       35  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000 -0.0000000000
       36  L B3gAr dyz     0.0000000000  0.0000000000  0.0000000000  0.0000000000
 
-* Electronic eigenvalue no. 33:  655381.86078552
+* Electronic eigenvalue no.***:  655381.86078552
 ====================================================
        1  L Ag Ar s      -1.1880917457  0.0000000000  0.0000000000  0.0000000000
        2  L Ag Ar s       0.8115329717  0.0000000000  0.0000000000  0.0000000000
@@ -4016,7 +4016,7 @@ tot.num. of pos.erg shells:    11    11    11
 
 * Gross populations greater than 0.00010
 
-Gross     Total   |    L Ag Ar s   
+Gross     Total   |    L Ag Ar s
 --------------------------------------
  alpha    1.0000  |      1.0000
  beta     0.0000  |      0.0000
@@ -4026,7 +4026,7 @@ Gross     Total   |    L Ag Ar s
 
 * Gross populations greater than 0.00010
 
-Gross     Total   |    L Ag Ar s   
+Gross     Total   |    L Ag Ar s
 --------------------------------------
  alpha    1.0000  |      1.0000
  beta     0.0000  |      0.0000
@@ -4036,7 +4036,7 @@ Gross     Total   |    L Ag Ar s
 
 * Gross populations greater than 0.00010
 
-Gross     Total   |    L Ag Ar s   
+Gross     Total   |    L Ag Ar s
 --------------------------------------
  alpha    1.0000  |      1.0000
  beta     0.0000  |      0.0000
@@ -4044,7 +4044,7 @@ Gross     Total   |    L Ag Ar s
 
 ** Total gross population of fermion ircop E1g **
 
-Gross      Total    |    L Ag Ar s   
+Gross      Total    |    L Ag Ar s
 --------------------------------------
  total     6.00000  |      6.00000
 
@@ -4063,7 +4063,7 @@ Gross      Total    |    L Ag Ar s
 
 * Gross populations greater than 0.00010
 
-Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz  
+Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz
 --------------------------------------------------------------------
  alpha    0.3333  |      0.0000         0.0000         0.3333
  beta     0.6667  |      0.3333         0.3333         0.0000
@@ -4073,7 +4073,7 @@ Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz
 
 * Gross populations greater than 0.00010
 
-Gross     Total   |    L B3uAr px     L B2uAr py  
+Gross     Total   |    L B3uAr px     L B2uAr py
 -----------------------------------------------------
  alpha    0.0000  |      0.0000         0.0000
  beta     1.0000  |      0.5000         0.5000
@@ -4083,7 +4083,7 @@ Gross     Total   |    L B3uAr px     L B2uAr py
 
 * Gross populations greater than 0.00010
 
-Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz  
+Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz
 --------------------------------------------------------------------
  alpha    0.6667  |      0.0000         0.0000         0.6667
  beta     0.3333  |      0.1667         0.1667         0.0000
@@ -4093,7 +4093,7 @@ Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz
 
 * Gross populations greater than 0.00010
 
-Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz  
+Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz
 --------------------------------------------------------------------
  alpha    0.3333  |      0.0000         0.0000         0.3333
  beta     0.6667  |      0.3333         0.3333         0.0000
@@ -4103,7 +4103,7 @@ Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz
 
 * Gross populations greater than 0.00010
 
-Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz  
+Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz
 --------------------------------------------------------------------
  alpha    0.6667  |      0.0000         0.0000         0.6667
  beta     0.3333  |      0.1667         0.1667         0.0000
@@ -4113,7 +4113,7 @@ Gross     Total   |    L B3uAr px     L B2uAr py     L B1uAr pz
 
 * Gross populations greater than 0.00010
 
-Gross     Total   |    L B3uAr px     L B2uAr py  
+Gross     Total   |    L B3uAr px     L B2uAr py
 -----------------------------------------------------
  alpha    0.0000  |      0.0000         0.0000
  beta     1.0000  |      0.5000         0.5000
@@ -4121,18 +4121,18 @@ Gross     Total   |    L B3uAr px     L B2uAr py
 
 ** Total gross population of fermion ircop E1u **
 
-Gross      Total    |    L B3uAr px     L B2uAr py     L B1uAr pz  
+Gross      Total    |    L B3uAr px     L B2uAr py     L B1uAr pz
 --------------------------------------------------------------------
  total    12.00000  |      4.00000        4.00000        4.00000
 
 
 *** Total gross population ***
 
-Gross      Total    |    L Ag Ar s      L B3uAr px     L B2uAr py     L B1uAr pz  
+Gross      Total    |    L Ag Ar s      L B3uAr px     L B2uAr py     L B1uAr pz
 -----------------------------------------------------------------------------------
  total    18.00000  |      6.00000        4.00000        4.00000        4.00000
 ===========================================================================
-* PCMOUT: Coefficients read from unformatted DFCOEF 
+* PCMOUT: Coefficients read from unformatted DFCOEF
           and written to formatted DFPCMO
 ===========================================================================
 
@@ -4334,7 +4334,7 @@ Gross      Total    |    L Ag Ar s      L B3uAr px     L B2uAr py     L B1uAr pz
    (LL|LL)ints :   0.00%
    Total       :   0.00%
 
------- Timing report (in CPU seconds) of module  integral transformation      
+------ Timing report (in CPU seconds) of module  integral transformation
 
 
 
@@ -4393,9 +4393,9 @@ Gross      Total    |    L Ag Ar s      L B3uAr px     L B2uAr py     L B1uAr pz
  * General print level   :   0
 
  Total memory available :       16384.00 MB   16.000 GB
- 
+
  INFO: No old restart file(s) found!
- 
+
 
  Configuration in highest pointgroup
 
@@ -4428,7 +4428,7 @@ Gross      Total    |    L Ag Ar s      L B3uAr px     L B2uAr py     L B1uAr pz
  Timing information      :                 F
  Print level          :                    0
  Memory limit (MWord) :                      2048
- Interface used       :                DIRAC6    
+ Interface used       :                DIRAC6
 
 
  Leave after calculating the total memory demand :          F
@@ -4447,22 +4447,22 @@ Gross      Total    |    L Ag Ar s      L B3uAr px     L B2uAr py     L B1uAr pz
  Type VOVO :          441558 integrals
  Type VOVV :         1320516 integrals
  Type VVVV :         3965355 integrals
- 
+
  Start sorting of integral classes at   9 Nov 22 13:20:56
- 
- 
+
+
  Sorting of first 4 classes done at   9 Nov 22 13:20:57
 
  Need      1 passes to sort VOVV integrals
- 
+
  Pass     1 ended at   9 Nov 22 13:20:59
- 
+
  VOVV sorting done at   9 Nov 22 13:20:59
 
  Need      1 passes to sort VVVV integrals
- 
+
  Pass     1 ended at   9 Nov 22 13:21:00
- 
+
  VVVV sorting done at   9 Nov 22 13:21:00
 
  Reading Coulomb integrals :
@@ -4622,13 +4622,13 @@ Gross      Total    |    L Ag Ar s      L B3uAr px     L B2uAr py     L B1uAr pz
  The time is :  13:21:02
 
  Status of the calculations
- Integral sort # 1 :                   Completed, restartable        
- Integral sort # 2 :                   Completed, restartable        
- Fock matrix build :                   Completed, restartable        
- MP2 energy calculation :              Completed, restartable        
- CCSD energy calculation :             Completed, restartable        
- CCSD(T) energy calculation :          Completed, restartable        
- CCSD(T) energy calculation :          Completed, restartable        
+ Integral sort # 1 :                   Completed, restartable
+ Integral sort # 2 :                   Completed, restartable
+ Fock matrix build :                   Completed, restartable
+ MP2 energy calculation :              Completed, restartable
+ CCSD energy calculation :             Completed, restartable
+ CCSD(T) energy calculation :          Completed, restartable
+ CCSD(T) energy calculation :          Completed, restartable
 
  Overview of calculated energies
 @ SCF energy :                              -528.633321041711156
@@ -4646,7 +4646,7 @@ Gross      Total    |    L Ag Ar s      L B3uAr px     L B2uAr py     L B1uAr pz
 
 --------------------------------------------------------------------------------
 
------- Timing report (in CPU seconds) of module  RELCCSD                      
+------ Timing report (in CPU seconds) of module  RELCCSD
 
 
 
@@ -4777,35 +4777,35 @@ Gross      Total    |    L Ag Ar s      L B3uAr px     L B2uAr py     L B1uAr pz
 *****************************************************
 
 
- 
+
      Date and time (Linux)  : Wed Nov  9 13:21:04 2022
-     Host name              : relqc01                                 
+     Host name              : relqc01
 
 >>>> Node 0, utime: 9, stime: 2, minflt: 23245, majflt: 38, nvcsw: 723, nivcsw: 448, maxrss: 181472
 >>>> Total WALL time used in DIRAC: 13s
-  
+
   Dynamical Memory Usage Summary for Master
-  
+
   Mean allocation size (Mb) :        27.62
-  
+
   Largest                    10  allocations
-  
-      488.28 Mb at subroutine pamprp_1_+0xa9                             for WORK in PAMPRP_1                          
-      488.28 Mb at subroutine pamtra_+0x134                              for WORK in PAMTRA                            
-      488.28 Mb at subroutine pamana_+0x89                               for WORK in PAMANA                            
-      488.28 Mb at subroutine psiscf_+0x99                               for WORK in PSISCF                            
-      488.28 Mb at subroutine pamset_+0x336                              for WORK in PAMSET - 2                        
-      488.28 Mb at subroutine gmotra_+0x42e0                             for WORK in GMOTRA - part 2                   
-      488.28 Mb at subroutine gmotra_+0x4cd8                             for WORK in GMOTRA                            
-      488.28 Mb at subroutine pamset_+0x86                               for WORK in PAMSET - 1                        
+
+      488.28 Mb at subroutine pamprp_1_+0xa9                             for WORK in PAMPRP_1
+      488.28 Mb at subroutine pamtra_+0x134                              for WORK in PAMTRA
+      488.28 Mb at subroutine pamana_+0x89                               for WORK in PAMANA
+      488.28 Mb at subroutine psiscf_+0x99                               for WORK in PSISCF
+      488.28 Mb at subroutine pamset_+0x336                              for WORK in PAMSET - 2
+      488.28 Mb at subroutine gmotra_+0x42e0                             for WORK in GMOTRA - part 2
+      488.28 Mb at subroutine gmotra_+0x4cd8                             for WORK in GMOTRA
+      488.28 Mb at subroutine pamset_+0x86                               for WORK in PAMSET - 1
       488.28 Mb at subroutine MAIN__+0x9be                               for test allocation of work array in DIRAC mai
-       30.28 Mb at subroutine ccseti_+0x6f9                              for vta                                       
-  
+       30.28 Mb at subroutine ccseti_+0x6f9                              for vta
+
   Peak memory usage:       488.32 MB
   Peak memory usage:        0.477 GB
-       reached at subroutine : butobs_no_work_+0x79                      
-              for variable   : buf in butobs                             
-  
+       reached at subroutine : butobs_no_work_+0x79
+              for variable   : buf in butobs
+
  MEMGET high-water mark:     0.00 MB
 
 *****************************************************


### PR DESCRIPTION
- Implemented a workaround for the case when the eigenvalue no is ***.
- Assume that the no is the following number after the previous eigenvalue no.