### PR TITLE
Pyproject and readme chore

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ optional arguments (--input is required)
 
 - LGPL v2.1
 
+## Maintainer
+
+- Minori Abe
+
 ## Author
 
 - Kohei Noda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sum_dirac_dfcoef"
 dynamic = ["version"]
 description = 'This is a utility to summarize the contribution of each atomic orbital per molecular orbital from the DIRAC output file that the *PRIVEC and .VECPRI options are used.'
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 license = "MIT"
 keywords = []
 authors = [
@@ -16,7 +16,6 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
- Pythonの最低バージョンが3.7であることをpypi.orgに表示させるために、pyproject.tomlを変更
- README.mdにメンテナ情報を追加
- (リポジトリ移譲後、正常にpypi.orgにパッケージをアップロードできるかどうかのテストでもある)