### PR TITLE
Add regex pattern for .SCF section in electron_num.py

### DIFF
--- a/src/sum_dirac_dfcoef/electron_num.py
+++ b/src/sum_dirac_dfcoef/electron_num.py
@@ -36,7 +36,8 @@ Please check your DIRAC input file and try again.\n"
     is_scf_found: bool = False
     scf_detail_section: bool = False
     # *section name or **section name
-    regex_section = r"^\*{1,2}[0-9A-Z]+"
+    regex_section = r" *\*{1,2}[0-9A-Z]+"
+    regex_scf = r" *\.SCF"
     for line in dirac_output:
         words = space_separated_parsing(line)
         words = [word.upper() for word in words]
@@ -52,7 +53,7 @@ Please check your DIRAC input file and try again.\n"
         if is_reach_input_field:
             if len(words) == 0:
                 continue
-            if ".SCF" in words[0]:
+            if re.match(regex_scf, words[0]) is not None:
                 is_scf_found = True
 
             if re.match(regex_section, words[0]) is not None:


### PR DESCRIPTION
- DIRACのアウトプットに書かれたインプットの情報にスペースが書かれている場合があるので、正規表現でスペースがある場合にも対応
  - re.matchを使うことで.SCFの前にコメントアウトがあるようなパターン(!.SCF)にはマッチせず、SCFの設定がされていない場合を検出できる
https://github.com/RQC-HU/sum_dirac_dfcoef/blob/14915ab80a53b506c50d0b75153979c07ebef415/src/sum_dirac_dfcoef/electron_num.py#L39-L40