### PR TITLE
Fix PrintVersionExitAction call signature

### DIFF
--- a/src/sum_dirac_dfcoef/args.py
+++ b/src/sum_dirac_dfcoef/args.py
@@ -12,7 +12,7 @@ class PrintVersionExitAction(argparse.Action):
             help=help,
         )
 
-    def __call__(self):
+    def __call__(self, parser, namespace, values, option_string=None):  # noqa: ARG002
         from sum_dirac_dfcoef.__about__ import __version__
 
         print(f"{__version__}")

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -123,3 +123,21 @@ def test_sum_dirac_dfcoeff(ref_filename: str, result_filename: str, input_filena
             out_list_str = " ".join(out[:-1])
         assert ref_list_str == out_list_str, f"line {line_idx}: {ref_list_str} != {out_list_str}\nref: {ref_list[line_idx]}\nout:{result_list[line_idx]}"
         assert ref_value == pytest.approx(out_value, abs=threshold), f"line {line_idx}: {ref_value} != {out_value}\nref: {ref_list[line_idx]}\nout:{result_list[line_idx]}"
+
+
+def test_version_option():
+    command = "sum_dirac_dfcoef -v"
+    p = subprocess.run(command.split(), encoding="utf-8", check=True, stdout=subprocess.PIPE)
+    # p.stdout = x.y.z\n
+    out_version_str = p.stdout.rstrip("\n")
+    about_file = Path(__file__).resolve().parent.parent / "src/sum_dirac_dfcoef/__about__.py"
+    # readline() => __version__ = "x.y.z"
+    # split()[-1] => "x.y.z"
+    # replace() => x.y.z
+    ref_version_str = open(about_file).readline().split()[-1].replace('"', "")
+    assert out_version_str == ref_version_str
+
+
+def test_help_option():
+    command = "sum_dirac_dfcoef -h"
+    subprocess.run(command.split(), check=True)


### PR DESCRIPTION
リファクタリングでPrintVersionExitActionの__call__関数で使っていない変数を消したが
argparse.Action.__call__関数は5つの引数があることを予期しているので、関数内で使わなくてもオプションとしては必要だった

```
$ sum_dirac_dfcoef -v
Traceback (most recent call last):
  File "/home/noda/.pyenv/versions/3.9.15/bin/sum_dirac_dfcoef", line 5, in <module>
    from sum_dirac_dfcoef import main
  File "/home/noda/develop/sum_dirac_dfcoef/src/sum_dirac_dfcoef/__init__.py", line 1, in <module>
    from sum_dirac_dfcoef.sum_dirac_dfcoef import main  # noqa: F401
  File "/home/noda/develop/sum_dirac_dfcoef/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py", line 8, in <module>
    from sum_dirac_dfcoef.args import args
  File "/home/noda/develop/sum_dirac_dfcoef/src/sum_dirac_dfcoef/args.py", line 56, in <module>
    args = parse_args()
  File "/home/noda/develop/sum_dirac_dfcoef/src/sum_dirac_dfcoef/args.py", line 53, in parse_args
    return parser.parse_args()
  File "/home/noda/.pyenv/versions/3.9.15/lib/python3.9/argparse.py", line 1825, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/home/noda/.pyenv/versions/3.9.15/lib/python3.9/argparse.py", line 1858, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/home/noda/.pyenv/versions/3.9.15/lib/python3.9/argparse.py", line 2067, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/home/noda/.pyenv/versions/3.9.15/lib/python3.9/argparse.py", line 2007, in consume_optional
    take_action(action, args, option_string)
  File "/home/noda/.pyenv/versions/3.9.15/lib/python3.9/argparse.py", line 1935, in take_action
    action(self, namespace, argument_values, option_string)
TypeError: __call__() takes 1 positional argument but 5 were given
```

したがって引数を元に戻し、LinterがWarningを出すので  # noqa: ARG002をつけてWarningを出さないようにした

また、DIRACのアウトプットを読む以外の動作をするオプションsum_dirac_dfcoef -h および sum_dirac_dfcoef -vのテストを追加して、今後これらのオプションが正常動作しなくなったとき検出できるようにした