### PR TITLE
Refactor redundant codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 
 ## Custom
 functions_info.json
+sum_dirac_dfcoef.out

--- a/src/sum_dirac_dfcoef/data.py
+++ b/src/sum_dirac_dfcoef/data.py
@@ -42,3 +42,7 @@ class DataAllMO:
 
     def __repr__(self) -> str:
         return f"electronic: {self.electronic}, positronic: {self.positronic}"
+
+    def sort_mo_energy(self) -> None:
+        self.electronic.sort(key=lambda mo: mo.mo_energy)
+        self.positronic.sort(key=lambda mo: mo.mo_energy)

--- a/src/sum_dirac_dfcoef/eigenvalues.py
+++ b/src/sum_dirac_dfcoef/eigenvalues.py
@@ -4,7 +4,7 @@ from io import TextIOWrapper
 from typing import ClassVar, Dict, List
 from typing import OrderedDict as ODict
 
-from sum_dirac_dfcoef.utils import debug_print, is_dirac_input_line_comment_out, is_dirac_input_section_one_star, space_separated_parsing
+from sum_dirac_dfcoef.utils import debug_print, is_dirac_input_line_comment_out, is_dirac_input_section_one_star, space_separated_parsing, space_separated_parsing_upper
 
 
 # type definition eigenvalues.shell_num
@@ -148,7 +148,7 @@ class Eigenvalues:
         is_scf_detail_section: bool = False
         is_next_line_eigpri: bool = False
         for line in dirac_output:
-            words: List[str] = [v.upper() for v in space_separated_parsing(line)]
+            words = space_separated_parsing_upper(line)
             if len(words) == 0 or is_dirac_input_line_comment_out(words[0]):
                 continue
 

--- a/src/sum_dirac_dfcoef/eigenvalues.py
+++ b/src/sum_dirac_dfcoef/eigenvalues.py
@@ -4,7 +4,7 @@ from io import TextIOWrapper
 from typing import ClassVar, Dict, List
 from typing import OrderedDict as ODict
 
-from sum_dirac_dfcoef.utils import debug_print, is_dirac_input_line_comment_out, is_dirac_input_section_one_star, space_separated_parsing, space_separated_parsing_upper
+from sum_dirac_dfcoef.utils import debug_print, is_dirac_input_line_should_be_skipped, is_dirac_input_section_one_star, space_separated_parsing, space_separated_parsing_upper
 
 
 # type definition eigenvalues.shell_num
@@ -149,7 +149,7 @@ class Eigenvalues:
         is_next_line_eigpri: bool = False
         for line in dirac_output:
             words = space_separated_parsing_upper(line)
-            if len(words) == 0 or is_dirac_input_line_comment_out(words[0]):
+            if is_dirac_input_line_should_be_skipped(words):
                 continue
 
             if is_start_dirac_input_field(line):

--- a/src/sum_dirac_dfcoef/eigenvalues.py
+++ b/src/sum_dirac_dfcoef/eigenvalues.py
@@ -141,22 +141,23 @@ class Eigenvalues:
         debug_print(f"eigenvalues: {self}")
 
     def validate_eigpri_option(self, dirac_output: TextIOWrapper):
-        from sum_dirac_dfcoef.utils import delete_comment_out, is_dirac_input_keyword, is_end_dirac_input_field, is_start_dirac_input_field
+        from sum_dirac_dfcoef.utils import delete_dirac_input_comment_out, is_dirac_input_keyword, is_end_dirac_input_field, is_start_dirac_input_field
 
         is_reach_input_field: bool = False
         is_scf_section: bool = False
         is_scf_detail_section: bool = False
         is_next_line_eigpri: bool = False
         for line in dirac_output:
-            words = space_separated_parsing_upper(line)
+            no_comment_out_line = delete_dirac_input_comment_out(line)
+            words = space_separated_parsing_upper(no_comment_out_line)
             if is_dirac_input_line_should_be_skipped(words):
                 continue
 
-            if is_start_dirac_input_field(line):
+            if is_start_dirac_input_field(no_comment_out_line):
                 is_reach_input_field = True
                 continue
 
-            if is_end_dirac_input_field(line):
+            if is_end_dirac_input_field(no_comment_out_line):
                 break
 
             if is_reach_input_field:
@@ -185,8 +186,6 @@ class Eigenvalues:
 
             if is_next_line_eigpri:
                 # https://diracprogram.org/doc/master/manual/wave_function/scf.html#eigpri
-                without_comment = delete_comment_out(line)
-                words = space_separated_parsing(without_comment)
                 if len(words) == 2 and words[0].isdigit() and words[1].isdigit():
                     if int(words[0]) == 0:  # positive energy eigenvalues are not printed
                         msg = f"\nYour .EIGPRI option in your DIRAC input file is invalid!\n\

--- a/src/sum_dirac_dfcoef/eigenvalues.py
+++ b/src/sum_dirac_dfcoef/eigenvalues.py
@@ -4,7 +4,17 @@ from io import TextIOWrapper
 from typing import ClassVar, Dict, List
 from typing import OrderedDict as ODict
 
-from sum_dirac_dfcoef.utils import debug_print, is_dirac_input_line_should_be_skipped, is_dirac_input_section_one_star, space_separated_parsing, space_separated_parsing_upper
+from sum_dirac_dfcoef.utils import (
+    debug_print,
+    delete_dirac_input_comment_out,
+    is_dirac_input_keyword,
+    is_dirac_input_line_should_be_skipped,
+    is_dirac_input_section_one_star,
+    is_end_dirac_input_field,
+    is_start_dirac_input_field,
+    space_separated_parsing,
+    space_separated_parsing_upper,
+)
 
 
 # type definition eigenvalues.shell_num
@@ -141,7 +151,6 @@ class Eigenvalues:
         debug_print(f"eigenvalues: {self}")
 
     def validate_eigpri_option(self, dirac_output: TextIOWrapper):
-        from sum_dirac_dfcoef.utils import delete_dirac_input_comment_out, is_dirac_input_keyword, is_end_dirac_input_field, is_start_dirac_input_field
 
         is_reach_input_field: bool = False
         is_scf_section: bool = False

--- a/src/sum_dirac_dfcoef/eigenvalues.py
+++ b/src/sum_dirac_dfcoef/eigenvalues.py
@@ -30,7 +30,7 @@ class Eigenvalues:
 
     def get_eigenvalues(self, dirac_output: TextIOWrapper):
         def is_end_of_read(line) -> bool:
-            if "Occupation" in line or "HOMO - LUMO" in line:
+            if "HOMO - LUMO" in line:
                 return True
             return False
 

--- a/src/sum_dirac_dfcoef/eigenvalues.py
+++ b/src/sum_dirac_dfcoef/eigenvalues.py
@@ -63,7 +63,7 @@ class Eigenvalues:
             return False
 
         def get_current_eigenvalue_type(words: List[str]) -> str:
-            # words[0] = '*', words[1] = "Closed" or "Open" or "Virtual" or "Negative"
+            # words[0] = '*', words[1] = "Closed" or "Open" or "Virtual" or "Negative" or "Positronic"
             current_eigenvalue_type = words[1].lower()
             return current_eigenvalue_type
 
@@ -139,7 +139,7 @@ class Eigenvalues:
                     match = re.search(regex, line[start_idx:])
                     if match is None:
                         break
-                    # [1 : len(match.group()) - 1] => ( 2) => 2
+                    # match.group() == ( 2) => [1 : len(match.group()) - 1] == 2
                     num = int(match.group()[1 : len(match.group()) - 1])
                     self.shell_num[current_symmetry_type][current_eigenvalue_type] += num
                     for _ in range(0, num, 2):
@@ -151,6 +151,13 @@ class Eigenvalues:
         debug_print(f"eigenvalues: {self}")
 
     def validate_eigpri_option(self, dirac_output: TextIOWrapper):
+        """Validate the .EIGPRI option in the DIRAC input file,
+        if is not set, it is a valid input
+        because only the positive energy eigenvalues are printed as default.
+
+        Args:
+            dirac_output (TextIOWrapper): _description_
+        """
 
         is_reach_input_field: bool = False
         is_scf_section: bool = False

--- a/src/sum_dirac_dfcoef/electron_num.py
+++ b/src/sum_dirac_dfcoef/electron_num.py
@@ -42,8 +42,6 @@ Please check your DIRAC input file and try again.\n"
     is_reach_input_field: bool = False
     is_scf_found: bool = False
     scf_detail_section: bool = False
-    # *section name or **section name
-    regex_scf_keyword = r" *\.SCF"
     for line in dirac_output:
         no_comment_out_line = delete_dirac_input_comment_out(line)
         words = space_separated_parsing_upper(no_comment_out_line)
@@ -59,7 +57,7 @@ Please check your DIRAC input file and try again.\n"
             break  # end of input field
 
         if is_reach_input_field:
-            if re.match(regex_scf_keyword, words[0]) is not None:
+            if ".SCF" in words[0]:
                 is_scf_found = True
 
             if is_dirac_input_section(words[0]):

--- a/src/sum_dirac_dfcoef/electron_num.py
+++ b/src/sum_dirac_dfcoef/electron_num.py
@@ -39,7 +39,6 @@ Please check your DIRAC input file and try again.\n"
     is_closed_shell_section: bool = False
     is_openshell_section: bool = False
     num_of_open_shell: int = 0
-    is_next_line_print_setting: bool = False
     is_reach_input_field: bool = False
     is_scf_found: bool = False
     scf_detail_section: bool = False
@@ -93,24 +92,6 @@ Please check your DIRAC input file and try again.\n"
                     for word in words:
                         electron_num += get_a_natural_number(word)
                     is_closed_shell_section = False
-
-                if is_next_line_print_setting:
-                    # https://gitlab.com/dirac/dirac/-/blob/79e6b9e27cf8018999ddca2aa72247ccfb9d2a2d/src/dirac/dirrdn.F#L2865-2876
-                    # ipreig = 0 (no eigenvalue printout) and 2 (only positronic eigenvalues written out)
-                    # are not supported because we cannot get electron number from them
-                    number = get_a_natural_number(words[0])
-                    ipreig = int(number)
-                    if ipreig in (0, 2):
-                        msg = ".PRINT setting in *SCF section with value 0 or 2 is not supported.\n\
-0 means no eigenvalue printout and 2 means only positronic eigenvalues written out.\n\
-Therefore we cannot get the information (e.g. orbital energies) from DIRAC output.\n\
-So we cannot continue this program because we need electron number and orbital energies to summarize DIRAC output.\n\
-Please check your DIRAC input file and try again.\n"
-                        raise ValueError(msg)
-                    is_next_line_print_setting = False
-
-                if ".PRINT" in line.upper():
-                    is_next_line_print_setting = True
 
                 # .CLOSED SHELL
                 if ".CLOSED" == words[0] and "SHELL" in words[1]:

--- a/src/sum_dirac_dfcoef/electron_num.py
+++ b/src/sum_dirac_dfcoef/electron_num.py
@@ -1,7 +1,14 @@
 import re
 from io import TextIOWrapper
 
-from sum_dirac_dfcoef.utils import is_dirac_input_line_comment_out, is_dirac_input_section, is_end_dirac_input_field, is_start_dirac_input_field, space_separated_parsing
+from sum_dirac_dfcoef.utils import (
+    is_dirac_input_line_comment_out,
+    is_dirac_input_section,
+    is_end_dirac_input_field,
+    is_start_dirac_input_field,
+    space_separated_parsing,
+    space_separated_parsing_upper,
+)
 
 
 def get_electron_num_from_input(dirac_output: TextIOWrapper) -> int:
@@ -39,8 +46,7 @@ Please check your DIRAC input file and try again.\n"
     regex_scf_keyword = r" *\.SCF"
     regex_comment_out = r" *[!#]"
     for line in dirac_output:
-        words = space_separated_parsing(line)
-        words = [word.upper() for word in words]
+        words = space_separated_parsing_upper(line)
 
         if len(words) == 0 or is_dirac_input_line_comment_out(words[0]):
             continue

--- a/src/sum_dirac_dfcoef/electron_num.py
+++ b/src/sum_dirac_dfcoef/electron_num.py
@@ -2,7 +2,7 @@ import re
 from io import TextIOWrapper
 
 from sum_dirac_dfcoef.utils import (
-    is_dirac_input_line_comment_out,
+    is_dirac_input_line_should_be_skipped,
     is_dirac_input_section,
     is_end_dirac_input_field,
     is_start_dirac_input_field,
@@ -48,7 +48,7 @@ Please check your DIRAC input file and try again.\n"
     for line in dirac_output:
         words = space_separated_parsing_upper(line)
 
-        if len(words) == 0 or is_dirac_input_line_comment_out(words[0]):
+        if is_dirac_input_line_should_be_skipped(words):
             continue
 
         if is_start_dirac_input_field(line):

--- a/src/sum_dirac_dfcoef/electron_num.py
+++ b/src/sum_dirac_dfcoef/electron_num.py
@@ -70,18 +70,18 @@ Please check your DIRAC input file and try again.\n"
 
             if scf_detail_section:
                 if is_openshell_section:
+                    # open shell format
+                    # https://diracprogram.org/doc/master/manual/wave_function/scf.html#open-shell
+                    # .OPEN SHELL
+                    # num_of_open_shell
+                    # num_of_elec/irrep1_num_spinor irrep2_num_spinor ...
+                    # We want to get only num_of_elec
                     if num_of_open_shell == 0:
                         num_of_open_shell = get_a_natural_number(words[0])
                     else:
-                        num_of_open_shell -= 1
-                        # open shell format
-                        # https://diracprogram.org/doc/master/manual/wave_function/scf.html#open-shell
-                        # .OPEN SHELL
-                        # num_of_open_shell
-                        # num_of_elec/irrep1_num_spinor irrep2_num_spinor ...
-                        # We want to get only num_of_elec
                         electron_num += get_a_natural_number(words[0])
-                        if num_of_open_shell == 0:
+                        num_of_open_shell -= 1  # Got an electron_num, so decrease the num_of_open_shell
+                        if num_of_open_shell == 0:  # Got all open shell electron_num
                             is_openshell_section = False
 
                 if is_closed_shell_section:

--- a/src/sum_dirac_dfcoef/electron_num.py
+++ b/src/sum_dirac_dfcoef/electron_num.py
@@ -23,7 +23,7 @@ def get_electron_num_from_input(dirac_output: TextIOWrapper) -> int:
             int: The number of electrons in the system
     """
 
-    def get_an_natural_number(word: str) -> int:
+    def get_a_natural_number(word: str) -> int:
         # OPEN SHELL and CLOSED SHELL electron number settings
         # must be written as a natural number (negative number is not allowed)
         regex_number = r"[-]?[0-9]+"
@@ -72,7 +72,7 @@ Please check your DIRAC input file and try again.\n"
             if scf_detail_section:
                 if is_openshell_section:
                     if num_of_open_shell == 0:
-                        num_of_open_shell = get_an_natural_number(words[0])
+                        num_of_open_shell = get_a_natural_number(words[0])
                     else:
                         num_of_open_shell -= 1
                         # open shell format
@@ -81,7 +81,7 @@ Please check your DIRAC input file and try again.\n"
                         # num_of_open_shell
                         # num_of_elec/irrep1_num_spinor irrep2_num_spinor ...
                         # We want to get only num_of_elec
-                        electron_num += get_an_natural_number(words[0])
+                        electron_num += get_a_natural_number(words[0])
                         if num_of_open_shell == 0:
                             is_openshell_section = False
 
@@ -91,14 +91,14 @@ Please check your DIRAC input file and try again.\n"
                     # .CLOSED SHELL
                     # irrep1_num_spinor irrep2_num_spinor ...
                     for word in words:
-                        electron_num += get_an_natural_number(word)
+                        electron_num += get_a_natural_number(word)
                     is_closed_shell_section = False
 
                 if is_next_line_print_setting:
                     # https://gitlab.com/kohei-noda/dirac/-/blob/79e6b9e27cf8018999ddca2aa72247ccfb9d2a2d/src/dirac/dirrdn.F#L2865-2876
                     # ipreig = 0 (no eigenvalue printout) and 2 (only positronic eigenvalues written out)
                     # are not supported because we cannot get electron number from them
-                    number = get_an_natural_number(words[0])
+                    number = get_a_natural_number(words[0])
                     ipreig = int(number)
                     if ipreig in (0, 2):
                         msg = ".PRINT setting in *SCF section with value 0 or 2 is not supported.\n\

--- a/src/sum_dirac_dfcoef/electron_num.py
+++ b/src/sum_dirac_dfcoef/electron_num.py
@@ -95,7 +95,7 @@ Please check your DIRAC input file and try again.\n"
                     is_closed_shell_section = False
 
                 if is_next_line_print_setting:
-                    # https://gitlab.com/kohei-noda/dirac/-/blob/79e6b9e27cf8018999ddca2aa72247ccfb9d2a2d/src/dirac/dirrdn.F#L2865-2876
+                    # https://gitlab.com/dirac/dirac/-/blob/79e6b9e27cf8018999ddca2aa72247ccfb9d2a2d/src/dirac/dirrdn.F#L2865-2876
                     # ipreig = 0 (no eigenvalue printout) and 2 (only positronic eigenvalues written out)
                     # are not supported because we cannot get electron number from them
                     number = get_a_natural_number(words[0])
@@ -131,7 +131,7 @@ But you cannot use the output using --no-scf option to dcaspt2_input_generator p
 
 
 def get_electron_num_from_scf_field(dirac_output: TextIOWrapper) -> int:
-    # https://gitlab.com/kohei-noda/dirac/-/blob/79e6b9e27cf8018999ddca2aa72247ccfb9d2a2d/src/dirac/dirrdn.F#L2127
+    # https://gitlab.com/dirac/dirac/-/blob/79e6b9e27cf8018999ddca2aa72247ccfb9d2a2d/src/dirac/dirrdn.F#L2127
     # find "i.e. no. of electrons ="
     is_wave_function_module_reached: bool = False
     for line in dirac_output:

--- a/src/sum_dirac_dfcoef/electron_num.py
+++ b/src/sum_dirac_dfcoef/electron_num.py
@@ -116,8 +116,7 @@ def get_electron_num_from_scf_field(dirac_output: TextIOWrapper) -> int:
     # find "i.e. no. of electrons ="
     is_wave_function_module_reached: bool = False
     for line in dirac_output:
-        no_comment_out_line = delete_dirac_input_comment_out(line)
-        words = space_separated_parsing(no_comment_out_line)
+        words = space_separated_parsing(line)
         if "Wave function module" in line:
             is_wave_function_module_reached = True
             continue

--- a/src/sum_dirac_dfcoef/header_info.py
+++ b/src/sum_dirac_dfcoef/header_info.py
@@ -138,7 +138,7 @@ class HeaderInfo:
         # \.{2} => ..
         regex = r"[-]?(?:[0-9]+|oo)\.{2}[-]?(?:[0-9]+|oo)"
         items: List[str] = re.findall(regex, range_str)
-        tmp_list: List[str] = []
+        ret_list: List[str] = []
         for item in items:
             item_li = item.replace("..", " ").split()
             range_li = [1 if item == "-oo" else len(self.eigenvalues.energies[symmetry_type]) if item == "oo" else int(item) for item in item_li]
@@ -146,5 +146,5 @@ class HeaderInfo:
                 msg = f"The minimum index is larger than the maximum index: {range_li[0]} > {range_li[1]}\n\
 your input: {range_str}, invalid input part: {item}"
                 raise ValueError(msg)
-            tmp_list.append(f"{range_li[0]}..{range_li[1]}")
-        return ",".join(tmp_list)
+            ret_list.append(f"{range_li[0]}..{range_li[1]}")
+        return ",".join(ret_list)

--- a/src/sum_dirac_dfcoef/header_info.py
+++ b/src/sum_dirac_dfcoef/header_info.py
@@ -29,6 +29,7 @@ class HeaderInfo:
             dirac_output (TextIOWrapper): Output file of DIRAC
 
         Returns:
+            None: class attributes are updated
         """
         dirac_output.seek(0)
         self.__read_electron_number(dirac_output)
@@ -55,7 +56,7 @@ class HeaderInfo:
         self.moltra_info.read_moltra_section(dirac_output)
 
     def __duplicate_moltra_str(self) -> None:
-        """Duplicate the moltra range string if it is not enough"""
+        # Duplicate the moltra range string if it is not enough
         if self.moltra_info.is_default:
             # Set the default range string
             for _ in range(len(self.eigenvalues.shell_num)):

--- a/src/sum_dirac_dfcoef/moltra.py
+++ b/src/sum_dirac_dfcoef/moltra.py
@@ -1,4 +1,3 @@
-import re
 from io import TextIOWrapper
 from typing import ClassVar, Dict, List
 
@@ -33,7 +32,6 @@ class MoltraInfo:
         """
 
         is_moltra_section = False
-        re_active_keyword = r" *\.ACTIVE"
         is_reach_input_field = False
         is_next_line_active = False
         for line in dirac_output:
@@ -56,7 +54,7 @@ class MoltraInfo:
                         continue
 
                 if is_moltra_section:
-                    if re.match(re_active_keyword, no_comment_line) is not None:
+                    if ".ACTIVE" in words[0]:
                         cls.is_default = False
                         is_next_line_active = True
                         continue

--- a/src/sum_dirac_dfcoef/moltra.py
+++ b/src/sum_dirac_dfcoef/moltra.py
@@ -5,7 +5,7 @@ from typing import ClassVar, Dict, List
 from sum_dirac_dfcoef.utils import (
     delete_comment_out,
     is_dirac_input_keyword,
-    is_dirac_input_line_comment_out,
+    is_dirac_input_line_should_be_skipped,
     is_dirac_input_section,
     is_dirac_input_section_two_stars,
     is_end_dirac_input_field,
@@ -38,7 +38,7 @@ class MoltraInfo:
         is_next_line_active = False
         for line in dirac_output:
             words = space_separated_parsing_upper(line)
-            if len(words) == 0 or is_dirac_input_line_comment_out(words[0]):
+            if is_dirac_input_line_should_be_skipped(words):
                 continue
 
             if is_start_dirac_input_field(line):

--- a/src/sum_dirac_dfcoef/moltra.py
+++ b/src/sum_dirac_dfcoef/moltra.py
@@ -10,7 +10,7 @@ from sum_dirac_dfcoef.utils import (
     is_dirac_input_section_two_stars,
     is_end_dirac_input_field,
     is_start_dirac_input_field,
-    space_separated_parsing,
+    space_separated_parsing_upper,
 )
 
 
@@ -37,7 +37,7 @@ class MoltraInfo:
         is_reach_input_field = False
         is_next_line_active = False
         for line in dirac_output:
-            words = [word.upper() for word in space_separated_parsing(line)]
+            words = space_separated_parsing_upper(line)
             if len(words) == 0 or is_dirac_input_line_comment_out(words[0]):
                 continue
 

--- a/src/sum_dirac_dfcoef/moltra.py
+++ b/src/sum_dirac_dfcoef/moltra.py
@@ -3,7 +3,7 @@ from io import TextIOWrapper
 from typing import ClassVar, Dict, List
 
 from sum_dirac_dfcoef.utils import (
-    delete_comment_out,
+    delete_dirac_input_comment_out,
     is_dirac_input_keyword,
     is_dirac_input_line_should_be_skipped,
     is_dirac_input_section,
@@ -37,7 +37,8 @@ class MoltraInfo:
         is_reach_input_field = False
         is_next_line_active = False
         for line in dirac_output:
-            words = space_separated_parsing_upper(line)
+            no_comment_line = delete_dirac_input_comment_out(line)
+            words = space_separated_parsing_upper(no_comment_line)
             if is_dirac_input_line_should_be_skipped(words):
                 continue
 
@@ -55,7 +56,7 @@ class MoltraInfo:
                         continue
 
                 if is_moltra_section:
-                    if re.match(re_active_keyword, line) is not None:
+                    if re.match(re_active_keyword, no_comment_line) is not None:
                         cls.is_default = False
                         is_next_line_active = True
                         continue
@@ -64,5 +65,4 @@ class MoltraInfo:
                     if is_dirac_input_section(words[0]) or is_dirac_input_keyword(words[0]):
                         # End of the .ACTIVE section
                         break
-                    no_comment_line = delete_comment_out(line)
                     cls.range_str.append(no_comment_line.strip())

--- a/src/sum_dirac_dfcoef/privec_reader.py
+++ b/src/sum_dirac_dfcoef/privec_reader.py
@@ -1,0 +1,183 @@
+import copy
+from io import TextIOWrapper
+from typing import List
+
+from sum_dirac_dfcoef.args import args
+from sum_dirac_dfcoef.atoms import AtomInfo
+from sum_dirac_dfcoef.coefficient import get_coefficient
+from sum_dirac_dfcoef.data import DataAllMO, DataMO
+from sum_dirac_dfcoef.functions_info import FunctionsInfo
+from sum_dirac_dfcoef.utils import (
+    debug_print,
+    space_separated_parsing,
+)
+
+
+def read_privec_data(dirac_output: TextIOWrapper, functions_info: FunctionsInfo) -> DataAllMO:
+    def is_this_row_for_coefficients(words: List[str]) -> bool:
+        # min: 4 coefficients and other words => 5 words
+        if 5 <= len(words) <= 9 and words[0].isdigit():
+            return True
+        else:
+            return False
+
+    def need_to_skip_this_line(words: List[str]) -> bool:
+        if len(words) <= 1:
+            return True
+        else:
+            return False
+
+    def need_to_create_results_for_current_mo(words: List[str], is_reading_coefficients: bool) -> bool:
+        if is_reading_coefficients and len(words) <= 1:
+            return True
+        else:
+            return False
+
+    def need_to_get_mo_sym_type(words: List[str], start_mo_coefficients: bool) -> bool:
+        if not start_mo_coefficients and len(words) == 3 and words[0] == "Fermion" and words[1] == "ircop":
+            return True
+        return False
+
+    def need_to_start_mo_section(words: List[str], start_mo_coefficients: bool) -> bool:
+        if not start_mo_coefficients and words[1] == "Electronic" and words[2] == "eigenvalue" and "no." in words[3]:
+            return True
+        elif not start_mo_coefficients and words[1] == "Positronic" and words[2] == "eigenvalue" and "no." in words[3]:
+            return True
+        return False
+
+    def check_start_vector_print(words: List[str]) -> bool:
+        # ****************************** Vector print ******************************
+        if len(words) < 4:
+            return False
+        elif words[1] == "Vector" and words[2] == "print":
+            return True
+        return False
+
+    def check_end_vector_print(
+        words: List[str],
+        start_vector_print: bool,
+        start_mo_section: bool,
+        start_mo_coefficients: bool,
+        is_reading_coefficients: bool,
+    ) -> bool:
+        # https://github.com/kohei-noda-qcrg/summarize_dirac_dfcoef_coefficients/issues/7#issuecomment-1377969626
+        if len(words) >= 2 and start_vector_print and start_mo_section and not start_mo_coefficients and not is_reading_coefficients:
+            return True
+        return False
+
+    is_electronic: bool = False
+    is_reading_coefficients: bool = False
+    start_mo_coefficients: bool = False
+    start_mo_section: bool = False
+    start_vector_print: bool = False
+    mo_sym_type: str = ""
+
+    data_mo = DataMO()
+    data_all_mo = DataAllMO()
+    used_atom_info: dict[str, AtomInfo] = {}
+    current_atom_info = AtomInfo()
+    # dirac_output.seek(0)  # rewind to the beginning of the file
+    for line_str in dirac_output:
+        words: List[str] = space_separated_parsing(line_str)
+
+        if not start_vector_print:
+            if check_start_vector_print(words):
+                start_vector_print = True
+            continue
+
+        if need_to_get_mo_sym_type(words, start_mo_coefficients):
+            mo_sym_type = words[2]
+
+        elif need_to_skip_this_line(words):
+            if need_to_create_results_for_current_mo(words, is_reading_coefficients):
+                start_mo_coefficients = False
+                data_mo.fileter_coefficients_by_threshold()
+                if is_electronic:
+                    data_all_mo.electronic.append(copy.deepcopy(data_mo))
+                else:  # Positronic
+                    data_all_mo.positronic.append(copy.deepcopy(data_mo))
+                debug_print(f"End of reading {data_mo.electron_num}th MO")
+                is_reading_coefficients = False
+
+        elif need_to_start_mo_section(words, start_mo_coefficients):
+            """
+            (e.g.)
+            words = ["*", "Electronic", "eigenvalue", "no.", "22:", "-2.8417809384721"]
+            words = ["*", "Electronic", "eigenvalue", "no.122:", "-2.8417809384721"]
+            """
+            start_mo_section = True
+            start_mo_coefficients = True
+            if words[1] == "Positronic":
+                is_electronic = False
+            elif words[1] == "Electronic":
+                is_electronic = True
+            else:
+                msg = f"UnKnow MO type, MO_Type={words[1]}"
+                raise Exception(msg)
+            try:
+                electron_num = int(words[-2][:-1].replace("no.", ""))
+            except ValueError:
+                # If *** is printed, we have no information about what number this MO is.
+                # Therefore, we assume that electron_num is the next number after prev_electron_num.
+                prev_electron_num = data_mo.electron_num  # prev_electron is the number of electrons of the previous MO
+                electron_num = prev_electron_num + 1
+            mo_energy = float(words[-1])
+            mo_info = (
+                f"{mo_sym_type} {electron_num}"
+                if args.compress
+                else (f"Electronic no. {electron_num} {mo_sym_type}" if is_electronic else f"Positronic no. {electron_num} {mo_sym_type}")
+            )
+            # Here is the start point of reading coefficients of the current MO
+            data_mo.reset()  # reset data_mo because we need to delete data_mo of the previous MO
+            data_mo.electron_num = electron_num
+            data_mo.mo_energy = mo_energy
+            data_mo.mo_info = mo_info
+            used_atom_info.clear()  # reset used_atom_info because we need to delete used_atom_info of the previous MO
+
+        elif check_end_vector_print(
+            words,
+            start_vector_print,
+            start_mo_section,
+            start_mo_coefficients,
+            is_reading_coefficients,
+        ):
+            # End of reading coefficients
+            break
+
+        # Read coefficients or the end of coefficients section
+        elif start_mo_coefficients:
+            if not is_this_row_for_coefficients(words):
+                continue
+            is_reading_coefficients = True
+            component_func = "large" if line_str[10] == "L" else ("small" if line_str[10] == "S" else "")  # CLS
+            symmetry_label = line_str[12:15].strip()  # REP (e.g. "Ag "), symmetry_label="Ag"
+            atom_label = line_str[15:18].strip()  # NAMN (e.g. "Cm "), atom_labe="Cm"
+            gto_type = line_str[18:22].strip()  # GTOTYP (e.g. "s   "), gto_type="s"
+            label = symmetry_label + atom_label
+
+            if current_atom_info.count_remaining_functions() == 0 or label != current_atom_info.label:
+                # First, we need to read information about the current atom.
+                if label not in used_atom_info:
+                    # It is the first time to read information about the current atom.
+                    cur_atom_start_idx = 1
+                else:
+                    # It is not the first time to read information about the current atom.
+                    # So we need to read information about the previous atom from used_atom_info.
+                    # current start_idx = previous start_idx + previous mul
+                    cur_atom_start_idx = used_atom_info[label].start_idx + used_atom_info[label].mul
+                # Validate start_idx
+                if cur_atom_start_idx not in functions_info[component_func][symmetry_label][atom_label]:
+                    msg = f"start_idx={cur_atom_start_idx} is not found in functions_info[{component_func}][{symmetry_label}][{atom_label}]"
+                    raise Exception(msg)
+                # We can get information about the current atom from functions_info with start_idx.
+                current_atom_info = copy.deepcopy(functions_info[component_func][symmetry_label][atom_label][cur_atom_start_idx])
+                # Update used_atom_info with current_atom_info
+                used_atom_info[label] = copy.deepcopy(current_atom_info)
+
+            current_atom_info.decrement_function(gto_type)
+            data_mo.add_coefficient(get_coefficient(line_str, functions_info, current_atom_info.start_idx))
+
+    if not args.no_sort:
+        data_all_mo.electronic.sort(key=lambda x: x.mo_energy)
+        data_all_mo.positronic.sort(key=lambda x: x.mo_energy)
+    return data_all_mo

--- a/src/sum_dirac_dfcoef/privec_reader.py
+++ b/src/sum_dirac_dfcoef/privec_reader.py
@@ -16,12 +16,12 @@ from sum_dirac_dfcoef.utils import (
 
 class STAGE(Enum):
     # STAGE TRANSITION: INIT -> VECTOR_PRINT -> WAIT_END_READING_COEF -> END
-    #                                              ↓            ↑
-    #                                           MO_COEF -> READING_COEF
+    #                                             ↓               ↑
+    #                                      WAIT_FIRST_COEF -> READING_COEF
     INIT = auto()
     VECTOR_PRINT = auto()
     WAIT_END_READING_COEF = auto()
-    MO_COEF = auto()
+    WAIT_FIRST_COEF = auto()
     READING_COEF = auto()
     END = auto()
 
@@ -70,11 +70,11 @@ class PrivecProcessor:
                     self.mo_sym_type = words[2]
                 elif self.need_to_start_mo_section(words):
                     self.start_mo_section(words)
-                    self.transition_stage(STAGE.MO_COEF)
+                    self.transition_stage(STAGE.WAIT_FIRST_COEF)
                 elif self.check_end_vector_print(words):
                     self.transition_stage(STAGE.END)
 
-            elif self.stage == STAGE.MO_COEF:
+            elif self.stage == STAGE.WAIT_FIRST_COEF:
                 if self.is_this_row_for_coefficients(words):
                     self.add_coefficient(line_str)
                     self.transition_stage(STAGE.READING_COEF)

--- a/src/sum_dirac_dfcoef/privec_reader.py
+++ b/src/sum_dirac_dfcoef/privec_reader.py
@@ -178,6 +178,6 @@ def read_privec_data(dirac_output: TextIOWrapper, functions_info: FunctionsInfo)
             data_mo.add_coefficient(get_coefficient(line_str, functions_info, current_atom_info.start_idx))
 
     if not args.no_sort:
-        data_all_mo.electronic.sort(key=lambda x: x.mo_energy)
-        data_all_mo.positronic.sort(key=lambda x: x.mo_energy)
+        data_all_mo.sort_mo_energy()
+
     return data_all_mo

--- a/src/sum_dirac_dfcoef/privec_reader.py
+++ b/src/sum_dirac_dfcoef/privec_reader.py
@@ -15,8 +15,9 @@ from sum_dirac_dfcoef.utils import (
 
 
 class STAGE(Enum):
-    # STAGE TRANSITION: INIT -> VECTOR_PRINT -> WAIT_END_READING_COEF ->
-    # [MO_COEF -> READING_COEF -> WAIT_END_READING_COEF -> MO_COEF -> READING_COEF -> WAIT_END_READING_COEF -> ...] -> END
+    # STAGE TRANSITION: INIT -> VECTOR_PRINT -> WAIT_END_READING_COEF -> END
+    #                                              ↓            ↑
+    #                                           MO_COEF -> READING_COEF
     INIT = auto()
     VECTOR_PRINT = auto()
     WAIT_END_READING_COEF = auto()

--- a/src/sum_dirac_dfcoef/privec_reader.py
+++ b/src/sum_dirac_dfcoef/privec_reader.py
@@ -1,4 +1,5 @@
 import copy
+from enum import Enum, auto
 from io import TextIOWrapper
 from typing import List
 
@@ -13,39 +14,99 @@ from sum_dirac_dfcoef.utils import (
 )
 
 
-def read_privec_data(dirac_output: TextIOWrapper, functions_info: FunctionsInfo) -> DataAllMO:
-    def is_this_row_for_coefficients(words: List[str]) -> bool:
+class STAGE(Enum):
+    # STAGE TRANSITION: INIT -> VECTOR_PRINT -> WAIT_END_READING_COEF ->
+    # [MO_COEF -> READING_COEF -> WAIT_END_READING_COEF -> MO_COEF -> READING_COEF -> WAIT_END_READING_COEF -> ...] -> END
+    INIT = auto()
+    VECTOR_PRINT = auto()
+    WAIT_END_READING_COEF = auto()
+    MO_COEF = auto()
+    READING_COEF = auto()
+    END = auto()
+
+
+class PrivecProcessor:
+    def __init__(self, dirac_output: TextIOWrapper, functions_info: FunctionsInfo) -> None:
+        self.dirac_output = dirac_output
+        self.stage = STAGE.INIT
+        self.is_electronic = False
+        self.mo_sym_type = ""
+        self.functions_info = functions_info
+        self.data_mo = DataMO()
+        self.data_all_mo = DataAllMO()
+        self.used_atom_info: dict[str, AtomInfo] = {}
+        self.current_atom_info = AtomInfo()
+
+    def read_privec_data(self):
+        """Read coefficients from the output file of DIRAC and store them in data_all_mo.
+
+        self.data_all is the final result of this function. You can get all results from this variable except header information.
+        """
+        self.stage = STAGE.INIT
+        for line_str in self.dirac_output:
+            words = space_separated_parsing(line_str)
+
+            if self.stage == STAGE.END:
+                break  # End of reading coefficients
+
+            elif self.need_to_skip_this_line(words):
+                if self.stage == STAGE.READING_COEF:
+                    if self.need_to_create_results_for_current_mo(words):
+                        self.add_current_mo_data_to_data_all_mo()
+                        self.transition_stage(STAGE.WAIT_END_READING_COEF)
+
+            elif self.stage == STAGE.INIT:
+                if self.check_start_vector_print(words):
+                    self.transition_stage(STAGE.VECTOR_PRINT)
+
+            elif self.stage == STAGE.VECTOR_PRINT:
+                if self.need_to_get_mo_sym_type(words):
+                    self.mo_sym_type = words[2]
+                    self.transition_stage(STAGE.WAIT_END_READING_COEF)
+
+            elif self.stage == STAGE.WAIT_END_READING_COEF:
+                if self.need_to_get_mo_sym_type(words):
+                    self.mo_sym_type = words[2]
+                elif self.need_to_start_mo_section(words):
+                    self.start_mo_section(words)
+                    self.transition_stage(STAGE.MO_COEF)
+                elif self.check_end_vector_print(words):
+                    self.transition_stage(STAGE.END)
+
+            elif self.stage == STAGE.MO_COEF:
+                if self.is_this_row_for_coefficients(words):
+                    self.add_coefficient(line_str)
+                    self.transition_stage(STAGE.READING_COEF)
+
+            elif self.stage == STAGE.READING_COEF:
+                if self.is_this_row_for_coefficients(words):
+                    self.add_coefficient(line_str)
+
+        if not args.no_sort:
+            self.data_all_mo.sort_mo_energy()
+
+    def transition_stage(self, new_stage: STAGE) -> None:
+        self.stage = new_stage
+
+    def is_this_row_for_coefficients(self, words: List[str]) -> bool:
         # min: 4 coefficients and other words => 5 words
-        if 5 <= len(words) <= 9 and words[0].isdigit():
-            return True
-        else:
-            return False
+        return True if 5 <= len(words) <= 9 and words[0].isdigit() else False
 
-    def need_to_skip_this_line(words: List[str]) -> bool:
-        if len(words) <= 1:
-            return True
-        else:
-            return False
+    def need_to_skip_this_line(self, words: List[str]) -> bool:
+        return True if len(words) <= 1 else False
 
-    def need_to_create_results_for_current_mo(words: List[str], is_reading_coefficients: bool) -> bool:
-        if is_reading_coefficients and len(words) <= 1:
-            return True
-        else:
-            return False
+    def need_to_create_results_for_current_mo(self, words: List[str]) -> bool:
+        return True if self.stage == STAGE.READING_COEF and len(words) <= 1 else False
 
-    def need_to_get_mo_sym_type(words: List[str], start_mo_coefficients: bool) -> bool:
-        if not start_mo_coefficients and len(words) == 3 and words[0] == "Fermion" and words[1] == "ircop":
+    def need_to_get_mo_sym_type(self, words: List[str]) -> bool:
+        return True if len(words) == 3 and words[0] == "Fermion" and words[1] == "ircop" else False
+
+    def need_to_start_mo_section(self, words: List[str]) -> bool:
+        if words[1] in ("Electronic", "Positronic") and words[2] == "eigenvalue" and "no." in words[3]:
             return True
         return False
 
-    def need_to_start_mo_section(words: List[str], start_mo_coefficients: bool) -> bool:
-        if not start_mo_coefficients and words[1] == "Electronic" and words[2] == "eigenvalue" and "no." in words[3]:
-            return True
-        elif not start_mo_coefficients and words[1] == "Positronic" and words[2] == "eigenvalue" and "no." in words[3]:
-            return True
-        return False
-
-    def check_start_vector_print(words: List[str]) -> bool:
+    def check_start_vector_print(self, words: List[str]) -> bool:
         # ****************************** Vector print ******************************
         if len(words) < 4:
             return False
@@ -53,131 +114,86 @@ def read_privec_data(dirac_output: TextIOWrapper, functions_info: FunctionsInfo)
             return True
         return False
 
-    def check_end_vector_print(
-        words: List[str],
-        start_vector_print: bool,
-        start_mo_section: bool,
-        start_mo_coefficients: bool,
-        is_reading_coefficients: bool,
-    ) -> bool:
+    def check_end_vector_print(self, words: List[str]) -> bool:
         # https://github.com/kohei-noda-qcrg/summarize_dirac_dfcoef_coefficients/issues/7#issuecomment-1377969626
-        if len(words) >= 2 and start_vector_print and start_mo_section and not start_mo_coefficients and not is_reading_coefficients:
+        if len(words) >= 2 and self.stage == STAGE.WAIT_END_READING_COEF:
             return True
         return False
 
-    is_electronic: bool = False
-    is_reading_coefficients: bool = False
-    start_mo_coefficients: bool = False
-    start_mo_section: bool = False
-    start_vector_print: bool = False
-    mo_sym_type: str = ""
+    def start_mo_section(self, words: List[str]) -> None:
+        """
+        (e.g.)
+        words = ["*", "Electronic", "eigenvalue", "no.", "22:", "-2.8417809384721"]
+        words = ["*", "Electronic", "eigenvalue", "no.122:", "-2.8417809384721"]
+        """
 
-    data_mo = DataMO()
-    data_all_mo = DataAllMO()
-    used_atom_info: dict[str, AtomInfo] = {}
-    current_atom_info = AtomInfo()
-    # dirac_output.seek(0)  # rewind to the beginning of the file
-    for line_str in dirac_output:
-        words: List[str] = space_separated_parsing(line_str)
-
-        if not start_vector_print:
-            if check_start_vector_print(words):
-                start_vector_print = True
-            continue
-
-        if need_to_get_mo_sym_type(words, start_mo_coefficients):
-            mo_sym_type = words[2]
-
-        elif need_to_skip_this_line(words):
-            if need_to_create_results_for_current_mo(words, is_reading_coefficients):
-                start_mo_coefficients = False
-                data_mo.fileter_coefficients_by_threshold()
-                if is_electronic:
-                    data_all_mo.electronic.append(copy.deepcopy(data_mo))
-                else:  # Positronic
-                    data_all_mo.positronic.append(copy.deepcopy(data_mo))
-                debug_print(f"End of reading {data_mo.electron_num}th MO")
-                is_reading_coefficients = False
-
-        elif need_to_start_mo_section(words, start_mo_coefficients):
-            """
-            (e.g.)
-            words = ["*", "Electronic", "eigenvalue", "no.", "22:", "-2.8417809384721"]
-            words = ["*", "Electronic", "eigenvalue", "no.122:", "-2.8417809384721"]
-            """
-            start_mo_section = True
-            start_mo_coefficients = True
+        def set_is_electronic() -> None:
             if words[1] == "Positronic":
-                is_electronic = False
+                self.is_electronic = False
             elif words[1] == "Electronic":
-                is_electronic = True
+                self.is_electronic = True
             else:
-                msg = f"UnKnow MO type, MO_Type={words[1]}"
-                raise Exception(msg)
+                msg = f"ERROR: UnKnow MO type, MO_Type={words[1]}"
+                raise ValueError(msg)
+
+        def get_electron_num():
             try:
                 electron_num = int(words[-2][:-1].replace("no.", ""))
             except ValueError:
                 # If *** is printed, we have no information about what number this MO is.
                 # Therefore, we assume that electron_num is the next number after prev_electron_num.
-                prev_electron_num = data_mo.electron_num  # prev_electron is the number of electrons of the previous MO
+                prev_electron_num = self.data_mo.electron_num  # prev_electron is the number of electrons of the previous MO
                 electron_num = prev_electron_num + 1
-            mo_energy = float(words[-1])
-            mo_info = (
-                f"{mo_sym_type} {electron_num}"
-                if args.compress
-                else (f"Electronic no. {electron_num} {mo_sym_type}" if is_electronic else f"Positronic no. {electron_num} {mo_sym_type}")
-            )
-            # Here is the start point of reading coefficients of the current MO
-            data_mo.reset()  # reset data_mo because we need to delete data_mo of the previous MO
-            data_mo.electron_num = electron_num
-            data_mo.mo_energy = mo_energy
-            data_mo.mo_info = mo_info
-            used_atom_info.clear()  # reset used_atom_info because we need to delete used_atom_info of the previous MO
+            return electron_num
 
-        elif check_end_vector_print(
-            words,
-            start_vector_print,
-            start_mo_section,
-            start_mo_coefficients,
-            is_reading_coefficients,
-        ):
-            # End of reading coefficients
-            break
+        set_is_electronic()
+        electron_num = get_electron_num()
+        mo_energy = float(words[-1])
+        mo_info = (
+            f"{self.mo_sym_type} {electron_num}"
+            if args.compress
+            else (f"Electronic no. {electron_num} {self.mo_sym_type}" if self.is_electronic else f"Positronic no. {electron_num} {self.mo_sym_type}")
+        )
+        # Here is the start point of reading coefficients of the current MO
+        self.data_mo.reset()  # reset data_mo because we need to delete data_mo of the previous MO
+        self.data_mo.electron_num = electron_num
+        self.data_mo.mo_energy = mo_energy
+        self.data_mo.mo_info = mo_info
+        self.used_atom_info.clear()  # reset used_atom_info because we need to delete used_atom_info of the previous MO
 
-        # Read coefficients or the end of coefficients section
-        elif start_mo_coefficients:
-            if not is_this_row_for_coefficients(words):
-                continue
-            is_reading_coefficients = True
-            component_func = "large" if line_str[10] == "L" else ("small" if line_str[10] == "S" else "")  # CLS
-            symmetry_label = line_str[12:15].strip()  # REP (e.g. "Ag "), symmetry_label="Ag"
-            atom_label = line_str[15:18].strip()  # NAMN (e.g. "Cm "), atom_labe="Cm"
-            gto_type = line_str[18:22].strip()  # GTOTYP (e.g. "s   "), gto_type="s"
-            label = symmetry_label + atom_label
+    def add_coefficient(self, line_str: str) -> None:
+        component_func = "large" if line_str[10] == "L" else ("small" if line_str[10] == "S" else "")  # CLS
+        symmetry_label = line_str[12:15].strip()  # REP (e.g. "Ag "), symmetry_label="Ag"
+        atom_label = line_str[15:18].strip()  # NAMN (e.g. "Cm "), atom_labe="Cm"
+        gto_type = line_str[18:22].strip()  # GTOTYP (e.g. "s   "), gto_type="s"
+        label = symmetry_label + atom_label
 
-            if current_atom_info.count_remaining_functions() == 0 or label != current_atom_info.label:
-                # First, we need to read information about the current atom.
-                if label not in used_atom_info:
-                    # It is the first time to read information about the current atom.
-                    cur_atom_start_idx = 1
-                else:
-                    # It is not the first time to read information about the current atom.
-                    # So we need to read information about the previous atom from used_atom_info.
-                    # current start_idx = previous start_idx + previous mul
-                    cur_atom_start_idx = used_atom_info[label].start_idx + used_atom_info[label].mul
-                # Validate start_idx
-                if cur_atom_start_idx not in functions_info[component_func][symmetry_label][atom_label]:
-                    msg = f"start_idx={cur_atom_start_idx} is not found in functions_info[{component_func}][{symmetry_label}][{atom_label}]"
-                    raise Exception(msg)
-                # We can get information about the current atom from functions_info with start_idx.
-                current_atom_info = copy.deepcopy(functions_info[component_func][symmetry_label][atom_label][cur_atom_start_idx])
-                # Update used_atom_info with current_atom_info
-                used_atom_info[label] = copy.deepcopy(current_atom_info)
+        if self.current_atom_info.count_remaining_functions() == 0 or label != self.current_atom_info.label:
+            # First, we need to read information about the current atom.
+            if label not in self.used_atom_info:
+                # It is the first time to read information about the current atom.
+                cur_atom_start_idx = 1
+            else:
+                # It is not the first time to read information about the current atom.
+                # So we need to read information about the previous atom from used_atom_info.
+                # current start_idx = previous start_idx + previous mul
+                cur_atom_start_idx = self.used_atom_info[label].start_idx + self.used_atom_info[label].mul
+            # Validate start_idx
+            if cur_atom_start_idx not in self.functions_info[component_func][symmetry_label][atom_label]:
+                msg = f"start_idx={cur_atom_start_idx} is not found in functions_info[{component_func}][{symmetry_label}][{atom_label}]"
+                raise Exception(msg)
+            # We can get information about the current atom from functions_info with start_idx.
+            self.current_atom_info = copy.deepcopy(self.functions_info[component_func][symmetry_label][atom_label][cur_atom_start_idx])
+            # Update used_atom_info with current_atom_info
+            self.used_atom_info[label] = copy.deepcopy(self.current_atom_info)
 
-            current_atom_info.decrement_function(gto_type)
-            data_mo.add_coefficient(get_coefficient(line_str, functions_info, current_atom_info.start_idx))
+        self.current_atom_info.decrement_function(gto_type)
+        self.data_mo.add_coefficient(get_coefficient(line_str, self.functions_info, self.current_atom_info.start_idx))
 
-    if not args.no_sort:
-        data_all_mo.sort_mo_energy()
-
-    return data_all_mo
+    def add_current_mo_data_to_data_all_mo(self) -> None:
+        self.data_mo.fileter_coefficients_by_threshold()
+        if self.is_electronic:
+            self.data_all_mo.electronic.append(copy.deepcopy(self.data_mo))
+        else:
+            self.data_all_mo.positronic.append(copy.deepcopy(self.data_mo))
+        debug_print(f"End of reading {self.data_mo.electron_num}th MO")

--- a/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py
+++ b/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py
@@ -3,7 +3,7 @@ from sum_dirac_dfcoef.args import args
 from sum_dirac_dfcoef.file_writer import output_file_writer
 from sum_dirac_dfcoef.functions_info import get_functions_info
 from sum_dirac_dfcoef.header_info import HeaderInfo
-from sum_dirac_dfcoef.privec_reader import read_privec_data
+from sum_dirac_dfcoef.privec_reader import PrivecProcessor
 from sum_dirac_dfcoef.utils import get_dirac_filepath, should_write_electronic_results_to_file, should_write_positronic_results_to_file
 
 
@@ -24,12 +24,14 @@ def main() -> None:
         output_file_writer.write_no_header_info()
     else:
         output_file_writer.write_headerinfo(header_info)
-    data_all_mo = read_privec_data(dirac_output, functions_info)
 
-    if should_write_electronic_results_to_file():  # Electronic
-        # Write electronic results to the file
+    # Read coefficients from the output file of DIRAC and store them in data_all_mo.
+    privec_processor = PrivecProcessor(dirac_output, functions_info)
+    privec_processor.read_privec_data()
+    data_all_mo = privec_processor.data_all_mo
+
+    if should_write_electronic_results_to_file():
         add_blank_line = True if args.all_write else False
         output_file_writer.write_mo_data(data_all_mo.electronic, add_blank_line=add_blank_line)
-    if should_write_positronic_results_to_file():  # Positronic
-        # Write positronic results to the file
+    if should_write_positronic_results_to_file():
         output_file_writer.write_mo_data(data_all_mo.positronic, add_blank_line=False)

--- a/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py
+++ b/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py
@@ -1,85 +1,10 @@
 #!/usr/bin/env python3
-
-import copy
-import sys
-from pathlib import Path
-from typing import List
-
 from sum_dirac_dfcoef.args import args
-from sum_dirac_dfcoef.atoms import AtomInfo
-from sum_dirac_dfcoef.coefficient import get_coefficient
-from sum_dirac_dfcoef.data import DataAllMO, DataMO
 from sum_dirac_dfcoef.file_writer import output_file_writer
 from sum_dirac_dfcoef.functions_info import get_functions_info
 from sum_dirac_dfcoef.header_info import HeaderInfo
-from sum_dirac_dfcoef.utils import debug_print, space_separated_parsing
-
-
-def is_this_row_for_coefficients(words: List[str]) -> bool:
-    # min: 4 coefficients and other words => 5 words
-    if 5 <= len(words) <= 9 and words[0].isdigit():
-        return True
-    else:
-        return False
-
-
-def need_to_skip_this_line(words: List[str]) -> bool:
-    if len(words) <= 1:
-        return True
-    else:
-        return False
-
-
-def need_to_create_results_for_current_mo(words: List[str], is_reading_coefficients: bool) -> bool:
-    if is_reading_coefficients and len(words) <= 1:
-        return True
-    else:
-        return False
-
-
-def need_to_get_mo_sym_type(words: List[str], start_mo_coefficients: bool) -> bool:
-    if not start_mo_coefficients and len(words) == 3 and words[0] == "Fermion" and words[1] == "ircop":
-        return True
-    return False
-
-
-def need_to_start_mo_section(words: List[str], start_mo_coefficients: bool) -> bool:
-    if not start_mo_coefficients and words[1] == "Electronic" and words[2] == "eigenvalue" and "no." in words[3]:
-        return True
-    elif not start_mo_coefficients and words[1] == "Positronic" and words[2] == "eigenvalue" and "no." in words[3]:
-        return True
-    return False
-
-
-def get_dirac_filepath() -> Path:
-    if not args.file:
-        sys.exit("ERROR: DIRAC output file is not given. Please use -f option.")
-    elif not Path(args.file).exists():
-        sys.exit(f"ERROR: DIRAC output file is not found. file={args.file}")
-    path = Path(args.file)
-    return path
-
-
-def check_start_vector_print(words: List[str]) -> bool:
-    # ****************************** Vector print ******************************
-    if len(words) < 4:
-        return False
-    elif words[1] == "Vector" and words[2] == "print":
-        return True
-    return False
-
-
-def check_end_vector_print(
-    words: List[str],
-    start_vector_print: bool,
-    start_mo_section: bool,
-    start_mo_coefficients: bool,
-    is_reading_coefficients: bool,
-) -> bool:
-    # https://github.com/kohei-noda-qcrg/summarize_dirac_dfcoef_coefficients/issues/7#issuecomment-1377969626
-    if len(words) >= 2 and start_vector_print and start_mo_section and not start_mo_coefficients and not is_reading_coefficients:
-        return True
-    return False
+from sum_dirac_dfcoef.privec_reader import read_privec_data
+from sum_dirac_dfcoef.utils import get_dirac_filepath
 
 
 def should_write_positronic_results_to_file() -> bool:
@@ -97,140 +22,24 @@ def should_write_electronic_results_to_file() -> bool:
 
 
 def main() -> None:
-    is_electronic: bool = False
-    is_reading_coefficients: bool = False
-    start_mo_coefficients: bool = False
-    start_mo_section: bool = False
-    start_vector_print: bool = False
-    mo_sym_type: str = ""
-
     dirac_filepath = get_dirac_filepath()
     dirac_output = open(dirac_filepath, encoding="utf-8")
     dirac_output.seek(0)  # rewind to the beginning of the file
-    if (not args.no_scf):
+    if not args.no_scf:
         header_info = HeaderInfo()
         header_info.read_header_info(dirac_output)
     dirac_output.seek(0)
     functions_info = get_functions_info(dirac_output)
     output_file_writer.create_blank_file()
-    if (args.no_scf or args.positronic_write):
+    if args.no_scf or args.positronic_write:
         # If args.no_scf is True, we cannot get header_info from the output file of DIRAC.
         # also, if args.positronic_write is True, we do not need to write header_info to the output file.
         # because dcaspt2_input_generator program does not support positronic results.
         output_file_writer.write_no_header_info()
     else:
         output_file_writer.write_headerinfo(header_info)
+    data_all_mo = read_privec_data(dirac_output, functions_info)
 
-    data_mo = DataMO()
-    data_all_mo = DataAllMO()
-    used_atom_info: dict[str, AtomInfo] = {}
-    current_atom_info = AtomInfo()
-    dirac_output.seek(0)  # rewind to the beginning of the file
-    for line_str in dirac_output:
-        words: List[str] = space_separated_parsing(line_str)
-
-        if not start_vector_print:
-            if check_start_vector_print(words):
-                start_vector_print = True
-            continue
-
-        if need_to_get_mo_sym_type(words, start_mo_coefficients):
-            mo_sym_type = words[2]
-
-        elif need_to_skip_this_line(words):
-            if need_to_create_results_for_current_mo(words, is_reading_coefficients):
-                start_mo_coefficients = False
-                data_mo.fileter_coefficients_by_threshold()
-                if is_electronic:
-                    data_all_mo.electronic.append(copy.deepcopy(data_mo))
-                else:  # Positronic
-                    data_all_mo.positronic.append(copy.deepcopy(data_mo))
-                debug_print(f"End of reading {data_mo.electron_num}th MO")
-                is_reading_coefficients = False
-
-        elif need_to_start_mo_section(words, start_mo_coefficients):
-            """
-            (e.g.)
-            words = ["*", "Electronic", "eigenvalue", "no.", "22:", "-2.8417809384721"]
-            words = ["*", "Electronic", "eigenvalue", "no.122:", "-2.8417809384721"]
-            """
-            start_mo_section = True
-            start_mo_coefficients = True
-            if words[1] == "Positronic":
-                is_electronic = False
-            elif words[1] == "Electronic":
-                is_electronic = True
-            else:
-                msg = f"UnKnow MO type, MO_Type={words[1]}"
-                raise Exception(msg)
-            try:
-                electron_num = int(words[-2][:-1].replace("no.", ""))
-            except ValueError:
-                # If *** is printed, we have no information about what number this MO is.
-                # Therefore, we assume that electron_num is the next number after prev_electron_num.
-                prev_electron_num = data_mo.electron_num  # prev_electron is the number of electrons of the previous MO
-                electron_num = prev_electron_num + 1
-            mo_energy = float(words[-1])
-            mo_info = (
-                f"{mo_sym_type} {electron_num}"
-                if args.compress
-                else (f"Electronic no. {electron_num} {mo_sym_type}" if is_electronic else f"Positronic no. {electron_num} {mo_sym_type}")
-            )
-            # Here is the start point of reading coefficients of the current MO
-            data_mo.reset()  # reset data_mo because we need to delete data_mo of the previous MO
-            data_mo.electron_num = electron_num
-            data_mo.mo_energy = mo_energy
-            data_mo.mo_info = mo_info
-            used_atom_info.clear()  # reset used_atom_info because we need to delete used_atom_info of the previous MO
-
-        elif check_end_vector_print(
-            words,
-            start_vector_print,
-            start_mo_section,
-            start_mo_coefficients,
-            is_reading_coefficients,
-        ):
-            # End of reading coefficients
-            break
-
-        # Read coefficients or the end of coefficients section
-        elif start_mo_coefficients:
-            if not is_this_row_for_coefficients(words):
-                continue
-            is_reading_coefficients = True
-            component_func = "large" if line_str[10] == "L" else ("small" if line_str[10] == "S" else "")  # CLS
-            symmetry_label = line_str[12:15].strip()  # REP (e.g. "Ag "), symmetry_label="Ag"
-            atom_label = line_str[15:18].strip()  # NAMN (e.g. "Cm "), atom_labe="Cm"
-            gto_type = line_str[18:22].strip()  # GTOTYP (e.g. "s   "), gto_type="s"
-            label = symmetry_label + atom_label
-
-            if current_atom_info.count_remaining_functions() == 0 or label != current_atom_info.label:
-                # First, we need to read information about the current atom.
-                if label not in used_atom_info:
-                    # It is the first time to read information about the current atom.
-                    cur_atom_start_idx = 1
-                else:
-                    # It is not the first time to read information about the current atom.
-                    # So we need to read information about the previous atom from used_atom_info.
-                    # current start_idx = previous start_idx + previous mul
-                    cur_atom_start_idx = used_atom_info[label].start_idx + used_atom_info[label].mul
-                # Validate start_idx
-                if cur_atom_start_idx not in functions_info[component_func][symmetry_label][atom_label]:
-                    msg = f"start_idx={cur_atom_start_idx} is not found in functions_info[{component_func}][{symmetry_label}][{atom_label}]"
-                    raise Exception(msg)
-                # We can get information about the current atom from functions_info with start_idx.
-                current_atom_info = copy.deepcopy(functions_info[component_func][symmetry_label][atom_label][cur_atom_start_idx])
-                # Update used_atom_info with current_atom_info
-                used_atom_info[label] = copy.deepcopy(current_atom_info)
-
-            current_atom_info.decrement_function(gto_type)
-            data_mo.add_coefficient(get_coefficient(line_str, functions_info, current_atom_info.start_idx))
-
-    # End of reading file
-    # Write results to the file
-    if not args.no_sort:
-        data_all_mo.electronic.sort(key=lambda x: x.mo_energy)
-        data_all_mo.positronic.sort(key=lambda x: x.mo_energy)
     if should_write_electronic_results_to_file():  # Electronic
         # Write electronic results to the file
         add_blank_line = True if args.all_write else False

--- a/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py
+++ b/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py
@@ -4,21 +4,7 @@ from sum_dirac_dfcoef.file_writer import output_file_writer
 from sum_dirac_dfcoef.functions_info import get_functions_info
 from sum_dirac_dfcoef.header_info import HeaderInfo
 from sum_dirac_dfcoef.privec_reader import read_privec_data
-from sum_dirac_dfcoef.utils import get_dirac_filepath
-
-
-def should_write_positronic_results_to_file() -> bool:
-    if args.all_write or args.positronic_write:
-        return True
-    else:
-        return False
-
-
-def should_write_electronic_results_to_file() -> bool:
-    if args.all_write or not args.positronic_write:
-        return True
-    else:
-        return False
+from sum_dirac_dfcoef.utils import get_dirac_filepath, should_write_electronic_results_to_file, should_write_positronic_results_to_file
 
 
 def main() -> None:
@@ -33,7 +19,7 @@ def main() -> None:
     output_file_writer.create_blank_file()
     if args.no_scf or args.positronic_write:
         # If args.no_scf is True, we cannot get header_info from the output file of DIRAC.
-        # also, if args.positronic_write is True, we do not need to write header_info to the output file.
+        # also, if args.positronic_write is True, we do not need to write header_info to the output file
         # because dcaspt2_input_generator program does not support positronic results.
         output_file_writer.write_no_header_info()
     else:

--- a/src/sum_dirac_dfcoef/utils.py
+++ b/src/sum_dirac_dfcoef/utils.py
@@ -91,3 +91,21 @@ def get_dirac_filepath() -> Path:
         sys.exit(f"ERROR: DIRAC output file is not found. file={args.file}")
     path = Path(args.file)
     return path
+
+
+def should_write_positronic_results_to_file() -> bool:
+    from sum_dirac_dfcoef.args import args
+
+    if args.all_write or args.positronic_write:
+        return True
+    else:
+        return False
+
+
+def should_write_electronic_results_to_file() -> bool:
+    from sum_dirac_dfcoef.args import args
+
+    if args.all_write or not args.positronic_write:
+        return True
+    else:
+        return False

--- a/src/sum_dirac_dfcoef/utils.py
+++ b/src/sum_dirac_dfcoef/utils.py
@@ -64,6 +64,13 @@ def is_dirac_input_line_comment_out(word: str) -> bool:
     return re.match(regex_comment_out, word) is not None
 
 
+def is_dirac_input_line_should_be_skipped(words: List[str]) -> bool:
+    if len(words) == 0:
+        return True
+    if is_dirac_input_line_comment_out(words[0]):
+        return True
+    return False
+
 def delete_comment_out(line: str) -> str:
     regex_comment_out = r" *[!#]"
     idx_comment_out = re.search(regex_comment_out, line)

--- a/src/sum_dirac_dfcoef/utils.py
+++ b/src/sum_dirac_dfcoef/utils.py
@@ -7,6 +7,11 @@ def space_separated_parsing(line: str) -> List[str]:
     return [word for word in words if word != ""]
 
 
+def space_separated_parsing_upper(line: str) -> List[str]:
+    words = re.split(" +", line.rstrip("\n"))
+    return [word.upper() for word in words if word != ""]
+
+
 def debug_print(message: str):
     from sum_dirac_dfcoef.args import args
 

--- a/src/sum_dirac_dfcoef/utils.py
+++ b/src/sum_dirac_dfcoef/utils.py
@@ -1,4 +1,6 @@
 import re
+import sys
+from pathlib import Path
 from typing import List
 
 
@@ -71,9 +73,21 @@ def is_dirac_input_line_should_be_skipped(words: List[str]) -> bool:
         return True
     return False
 
+
 def delete_dirac_input_comment_out(line: str) -> str:
     regex_comment_out = r" *[!#]"
     idx_comment_out = re.search(regex_comment_out, line)
     if idx_comment_out is None:
         return line
     return line[: idx_comment_out.start()]
+
+
+def get_dirac_filepath() -> Path:
+    from sum_dirac_dfcoef.args import args
+
+    if not args.file:
+        sys.exit("ERROR: DIRAC output file is not given. Please use -f option.")
+    elif not Path(args.file).exists():
+        sys.exit(f"ERROR: DIRAC output file is not found. file={args.file}")
+    path = Path(args.file)
+    return path

--- a/src/sum_dirac_dfcoef/utils.py
+++ b/src/sum_dirac_dfcoef/utils.py
@@ -71,7 +71,7 @@ def is_dirac_input_line_should_be_skipped(words: List[str]) -> bool:
         return True
     return False
 
-def delete_comment_out(line: str) -> str:
+def delete_dirac_input_comment_out(line: str) -> str:
     regex_comment_out = r" *[!#]"
     idx_comment_out = re.search(regex_comment_out, line)
     if idx_comment_out is None:

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,3 @@
 !*.out
 result.*out
+sum_dirac_dfcoef.out

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,6 @@ import subprocess
 from pathlib import Path
 
 
-# def pytest_configure(config):
 def pytest_sessionstart():
     cur_dir = Path.cwd()
     # Change the current directory to the root directory of the package

--- a/test/update_reference_test_files.py
+++ b/test/update_reference_test_files.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import shutil
+from pathlib import Path
+
+
+def main():
+    """This script is used to update the ref.*.out files in the test/references directory
+    with the result.*.out files in the test/results directory.
+
+    This script is used when the results of the program are changed.
+    """
+    this_file_dir = Path(__file__).resolve().parent
+    results_dir = this_file_dir / "results"
+    references_dir = this_file_dir / "references"
+    result_list = list(results_dir.glob("result.*.out"))
+    for result in result_list:
+        # replace only the first occurrence of "result" with "reference"
+        ref_name = result.name.replace("result", "ref", 1)
+        ref_path = references_dir / ref_name
+        shutil.copy2(result, ref_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- 様々なコードのリファクタリングを行いました
  - コメントをいくつか追加したり、より分かりやすい表現に変えました
  - メインの処理であるところのPRIVECの内容を読む部分を[privec_reader.py](https://github.com/RQC-HU/sum_dirac_dfcoef/blob/8ea09d326b50366ceb90ec4fc791ed7b5344f0b5/src/sum_dirac_dfcoef/privec_reader.py)に分けてメイン関数の可読性を上げました
    - privec_readerの処理の状態遷移が分かりづらくなっていたので、STAGEクラスを作り、状態遷移を分かりやすくしました
    https://github.com/RQC-HU/sum_dirac_dfcoef/blob/8ea09d326b50366ceb90ec4fc791ed7b5344f0b5/src/sum_dirac_dfcoef/privec_reader.py#L17-L26
    https://github.com/RQC-HU/sum_dirac_dfcoef/blob/8ea09d326b50366ceb90ec4fc791ed7b5344f0b5/src/sum_dirac_dfcoef/privec_reader.py#L41-L87
  - utils.pyにいくつかの関数を移動させました
  - [number_of_infoは不必要なので削除](https://github.com/RQC-HU/sum_dirac_dfcoef/commit/3787a47a6bfdbb7f7321fd80b59ebb3724481f24)しました
  - [update_reference_test_files.py](https://github.com/RQC-HU/sum_dirac_dfcoef/blob/8ea09d326b50366ceb90ec4fc791ed7b5344f0b5/test/update_reference_test_files.py)を追加して、テストのリファレンスが仕様変更により変わったときに、リファレンスの変更を簡単にできるようにしました
  - [SCFの.PRINTオプションのバリデーションは消す必要があることが分かった](https://github.com/RQC-HU/sum_dirac_dfcoef/pull/62/commits/e555eef75e076f1b06d826e79c7b498c7caad386)ので削除しました