### PR TITLE
Gh actions permission

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: write
+
 jobs:
   test:
     uses: ./.github/workflows/reusable_test.yml

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -19,6 +19,10 @@ on:
         required: false
         default: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 env:
   NEW_VERSION: ""
   BRANCH_NAME: ""


### PR DESCRIPTION
- Organizationsのactionsによるリポジトリ操作の設定がデフォルトではすべてreadになっているためpublish-pr.ymlが走らない
  - https://docs.github.com/ja/actions/using-jobs/assigning-permissions-to-jobs を参考にして必要なオプションだけwrite権限に変えた