### PR TITLE
Supports multi-process parallelization

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ optional arguments (--input is required)
   This option is useful when you want to use the result of this program as input to dcaspt2_input_generator.
   This option is equivalent to set -c/--compress and not set -p/--positronic and --no-scf options.
 
+- -j [PARALLEL], --parallel [PARALLEL]
+
+  Number of parallel processes.
+  Default: 1 (single process).
+  If you set -j option without argument, the number of parallel processes is set to the number of CPU cores(=os.cpu_count()).
+
 - -c, --compress
 
   Compress output. Display all coefficients on one line for each MO.  

--- a/src/sum_dirac_dfcoef/args.py
+++ b/src/sum_dirac_dfcoef/args.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sys
 
 
@@ -41,6 +42,7 @@ This option is useful when you want to use the result of this program as input t
 This option is equivalent to set -c/--compress and not set -p/--positronic and --no-scf options.",
         dest="for_generator",
     )
+    parser.add_argument("-j", "--parallel", type=int, nargs="?", const=-1, default=1, help="Number of parallel processes. Default: 1", dest="parallel")
     parser.add_argument(
         "-c",
         "--compress",
@@ -87,6 +89,8 @@ This option is equivalent to set -c/--compress and not set -p/--positronic and -
     parser.add_argument("--no-sort", action="store_true", help="Don't sort the output by MO energy")
     # If -v or --version option is used, print version and exit
     args = parser.parse_args()
+
+    args.parallel = os.cpu_count() if args.parallel == -1 else args.parallel
 
     if args.for_generator:
         args.no_scf = False

--- a/src/sum_dirac_dfcoef/args.py
+++ b/src/sum_dirac_dfcoef/args.py
@@ -42,7 +42,17 @@ This option is useful when you want to use the result of this program as input t
 This option is equivalent to set -c/--compress and not set -p/--positronic and --no-scf options.",
         dest="for_generator",
     )
-    parser.add_argument("-j", "--parallel", type=int, nargs="?", const=-1, default=1, help="Number of parallel processes. Default: 1", dest="parallel")
+    parser.add_argument(
+        "-j",
+        "--parallel",
+        type=int,
+        nargs="?",
+        const=-1,
+        default=1,
+        help="Number of parallel processes. Default: 1 (single process).\
+        If you set -j option without argument, the number of parallel processes is set to the number of CPU cores(=os.cpu_count()).",
+        dest="parallel",
+    )
     parser.add_argument(
         "-c",
         "--compress",

--- a/src/sum_dirac_dfcoef/data.py
+++ b/src/sum_dirac_dfcoef/data.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Dict, List
+from typing import Dict, List, Optional
 
 from sum_dirac_dfcoef.args import args
 from sum_dirac_dfcoef.coefficient import Coefficient
@@ -10,8 +10,24 @@ class DataMO:
     mo_info: str = ""
     sym_type: str = ""
     eigenvalue_no: int = 0
-    coef_dict: ClassVar[Dict[str, Coefficient]] = {}
-    coef_list: ClassVar[List[Coefficient]] = []
+    coef_dict: Dict[str, Coefficient]
+    coef_list: List[Coefficient]
+
+    def __init__(
+        self,
+        mo_info: str = "",
+        mo_energy: float = 0.0,
+        eigenvalue_no: int = 0,
+        sym_type: str = "",
+        coef_dict: Optional[Dict[str, Coefficient]] = None,
+        coef_list: Optional[List[Coefficient]] = None,
+    ) -> None:
+        self.mo_info = mo_info
+        self.mo_energy = mo_energy
+        self.eigenvalue_no = eigenvalue_no
+        self.sym_type = sym_type
+        self.coef_dict = coef_dict if coef_dict is not None else {}
+        self.coef_list = coef_list if coef_list is not None else []
 
     def __repr__(self) -> str:
         return f"mo_info: {self.mo_info}, mo_energy: {self.mo_energy}, eigenvalue_no: {self.eigenvalue_no}, mo_sym_type: {self.sym_type}, coef_dict: {self.coef_dict}"
@@ -38,8 +54,12 @@ class DataMO:
 
 
 class DataAllMO:
-    electronic: ClassVar[List[DataMO]] = []
-    positronic: ClassVar[List[DataMO]] = []
+    electronic: List[DataMO]
+    positronic: List[DataMO]
+
+    def __init__(self, electronic: Optional[List[DataMO]] = None, positronic: Optional[List[DataMO]] = None) -> None:
+        self.electronic = electronic if electronic is not None else []
+        self.positronic = positronic if positronic is not None else []
 
     def __repr__(self) -> str:
         return f"electronic: {self.electronic}, positronic: {self.positronic}"

--- a/src/sum_dirac_dfcoef/eigenvalues.py
+++ b/src/sum_dirac_dfcoef/eigenvalues.py
@@ -2,7 +2,7 @@ import re
 from collections import OrderedDict
 from enum import Enum, auto
 from io import TextIOWrapper
-from typing import ClassVar, Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 from typing import OrderedDict as ODict
 
 from sum_dirac_dfcoef.utils import (
@@ -50,9 +50,19 @@ class StageEIGPRI(Enum):
 #     },
 # }
 class Eigenvalues:
-    shell_num: ClassVar[ODict[str, Dict[str, int]]] = OrderedDict()
-    energies: ClassVar[ODict[str, Dict[int, float]]] = OrderedDict()
-    energies_used: ClassVar[ODict[str, Dict[int, bool]]] = OrderedDict()
+    shell_num: ODict[str, Dict[str, int]]
+    energies: ODict[str, Dict[int, float]]
+    energies_used: ODict[str, Dict[int, bool]]
+
+    def __init__(
+        self,
+        shell_num: Optional[ODict[str, Dict[str, int]]] = None,
+        energies: Optional[ODict[str, Dict[int, float]]] = None,
+        energies_used: Optional[ODict[str, Dict[int, bool]]] = None,
+    ) -> None:
+        self.shell_num = shell_num if shell_num is not None else OrderedDict()
+        self.energies = energies if energies is not None else OrderedDict()
+        self.energies_used = energies_used if energies_used is not None else OrderedDict()
 
     def __repr__(self) -> str:
         return f"shell_num: {self.shell_num}\nenergies: {self.energies}\nenergies_used: {self.energies_used}"

--- a/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py
+++ b/src/sum_dirac_dfcoef/sum_dirac_dfcoef.py
@@ -18,10 +18,10 @@ def main() -> None:
     functions_info = get_functions_info(dirac_output)
     output_file_writer.create_blank_file()
 
+    dirac_output_lines = dirac_output.readlines()
     # Read coefficients from the output file of DIRAC and store them in data_all_mo.
-    privec_processor = PrivecProcessor(dirac_output, functions_info, header_info.eigenvalues)
-    privec_processor.read_privec_data()
-
+    privec_processor = PrivecProcessor(dirac_output_lines, functions_info, header_info.eigenvalues)
+    privec_processor.read_privec_data_wrapper()
 
     # Write the header information to the output file.
     if not args.for_generator:

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -43,6 +43,8 @@ def get_output_list(filepath: Path) -> List[List[str]]:
         ("ref.Cm3+_phen_reorder.compress.out"       , "result.Cm3+_phen_reorder.compress.out"       , "x2c_Cm3+_phen_reorder.out", "-d 15 -g"),
         ("ref.H2.no_scf.compress.out"               , "result.H2.no_scf.compress.out"               , "H2.noscf_H2.out"          , "-d 15 -c --no-scf"),
         ("ref.H2O.invalid.eigpri.compress.out"      , "result.H2O.invalid.eigpri.compress.out"      , "H2O.invalid.eigpri.out"   , "-d 15 -c --no-scf"),
+        # multiprocess (should be the same as the single process case)
+        ("ref.ucl4.compress.out"                    , "result.ucl4.compress.multi-process.out"      , "x2c_ucl4.out"             , "-j2 -d 15 -g"),
     ]
     # fmt: on
 )
@@ -96,6 +98,8 @@ def test_sum_dirac_dfcoeff_compress(ref_filename: str, result_filename: str, inp
         ("ref.ucl4.out"                     , "result.ucl4.out"                     , "x2c_ucl4.out"                    , "-d 15"),
         ("ref.ucl4.no_sort.out"             , "result.ucl4.no_sort.out"             , "x2c_ucl4.out"                    , "-d 15 --no-sort"),
         ("ref.Cm3+_phen.out"                , "result.Cm3+_phen.out"                , "x2c_Cm3+_phen.out"               , "-d 15"),
+        # multiprocess (should be the same as the single process case)
+        ("ref.uo2.out"                      , "result.uo2.multi-process.out"        , "x2c_uo2_238.out"                 , "-j2 -d 15"),
     ]
     # fmt: on
 )


### PR DESCRIPTION
- #77 で説明がある通り216MBのインプットファイルの場合 [privec_reader.pyのread_privec_data](https://github.com/RQC-HU/sum_dirac_dfcoef/blob/4d4d1ac0a9895d7fd07fa5c2b6a339cef915b523/src/sum_dirac_dfcoef/privec_reader.py#L42)関数が全体実行時間のほとんどを占めているので、マルチプロセス並列処理ができるようにしました
  - -j, --parallelオプションをつけると並列処理が行われます(-j 8だと8並列、-jだとCPUコアの数で並列)

216MBのデータの場合、1並列と比べて概ね3倍程度まで高速化されます
```
Start running "sum_dirac_dfcoef -j1 -i ./Cm3+_phen.out -g" for 5 times...
Total time: 225.5122283489909 sec
Average time: 45.10244566979818 sec
Start running "sum_dirac_dfcoef -j4 -i ./Cm3+_phen.out -g" for 5 times...
Total time: 109.67492689198116 sec
Average time: 21.93498537839623 sec
Start running "sum_dirac_dfcoef -j8 -i ./Cm3+_phen.out -g" for 5 times...
Total time: 92.90136299503502 sec
Average time: 18.580272599007003 sec
```