### PR TITLE
Handle exclusive command options

### DIFF
--- a/src/sum_dirac_dfcoef/args.py
+++ b/src/sum_dirac_dfcoef/args.py
@@ -101,6 +101,16 @@ This options is useful when you want to use the result in a spreadsheet like Mic
 
     args.parallel = os.cpu_count() if args.parallel == -1 else args.parallel
 
+    # -g and -p, --no-scf options are exclusive
+    if args.for_generator and args.positronic_write:
+        msg = "-g/--for-generator and -p/--positronic-write options cannot be set at the same time \
+because dcaspt2_input_generator needs data of electronic orbitals."
+        parser.error(msg)
+    if args.for_generator and args.no_scf:
+        msg = "-g/--for-generator and --no-scf options cannot be set at the same time \
+because dcaspt2_input_generator needs eigenvalues information after SCF calculation."
+        parser.error(msg)
+
     if args.for_generator:
         args.no_scf = False
         args.compress = True

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -151,8 +151,10 @@ def test_sum_dirac_dfcoeff(ref_filename: str, result_filename: str, input_filena
     "input_filename, options, expected_error_message",
     # fmt: off
     [
-        ("H2O.invalid.eigpri.out"  , "-g -d 15", "Your .EIGPRI option in your DIRAC input file is invalid!"),
-        ("H2.noscf_H2.out"         , "-g -d 15", "Cannot find SCF calculation settings"),
+        ("H2O.invalid.eigpri.out"  , "-g -d 15"    , "Your .EIGPRI option in your DIRAC input file is invalid!"),
+        ("H2.noscf_H2.out"         , "-g -d 15"    , "Cannot find SCF calculation settings"),
+        ("Ar_Ar.out"               , "-g --no-scf" , "-g/--for-generator and --no-scf options cannot be set at the same time"),
+        ("Ar_Ar.out"               , "-g -p"       , "-g/--for-generator and -p/--positronic-write options cannot be set at the same time"),
     ],
     # fmt: on
 )


### PR DESCRIPTION
dcaspt2_input_generatorが沢山の情報を必要とするので、sum_dirac_dfcoefの-pオプションや--no-scfオプションを付けたアウトプットを使用することができない

従って-g/--for-generatorオプションを付けた場合は-p/--positronicオプションや--no-scfを同時に指定するとエラーでプログラムを停止するようにした