### PR TITLE
Remove *.out files in the results directory at the beginning of test session.

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,6 +7,11 @@ def pytest_sessionstart():
     cur_dir = Path.cwd()
     # Change the current directory to the root directory of the package
     test_dir = Path(__file__).resolve().parent
+    results_dir = Path.joinpath(test_dir, "results")
+    if results_dir.exists():
+        # Remove *.out files in the results directory
+        for file in results_dir.glob("*.out"):
+            os.remove(file)
     os.chdir(Path.joinpath(test_dir, ".."))
     cmd = "python3 -m pip install -e .[test]"
     subprocess.run(cmd.split(), check=True)


### PR DESCRIPTION
- テスト開始時にアウトプットがあるなら削除しておかないと、ファイルが出力されなかったときに前のテスト結果を使ってしまう
  - したがってセッションの最初に結果の*.outファイルを削除するように変更