### PR TITLE
Add quote to args example

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ optional arguments (--input is required)
 
   show this help message and exit
 
-- -i "FILE", --input "FILE"
+- -i "INPUT", --input "INPUT"
 
   (required) file path of DIRAC output.  
   Please quote if the path include spaces.

--- a/README.md
+++ b/README.md
@@ -130,14 +130,16 @@ optional arguments (--input is required)
 
   show this help message and exit
 
-- -i FILE, --input FILE
+- -i "FILE", --input "FILE"
 
-  (required) file path of DIRAC output
+  (required) file path of DIRAC output.  
+  Please quote if the path include spaces.
 
-- -o OUTPUT, --output OUTPUT
+- -o "OUTPUT", --output "OUTPUT"
 
   Output file name.  
-  Default: sum_dirac_dfcoef.out
+  Default: sum_dirac_dfcoef.out.  
+  Please quote if the path include spaces.  
 
 - -g, --for-generator
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ optional arguments (--input is required)
 
 - -o "OUTPUT", --output "OUTPUT"
 
-  Output file name.  
+  File path of sum_dirac_dfcoef output.  
   Default: sum_dirac_dfcoef.out.  
   Please quote if the path include spaces.  
 

--- a/src/sum_dirac_dfcoef/args.py
+++ b/src/sum_dirac_dfcoef/args.py
@@ -35,7 +35,7 @@ def parse_args() -> "argparse.Namespace":
     parser = PrintHelpArgumentParser(
         description="Summarize the coefficients from DIRAC output file that *PRIVEC option is used. (c.f. http://www.diracprogram.org/doc/master/manual/analyze/privec.html)"
     )
-    parser.add_argument("-i", "--input", type=str, required=True, help="(required) file path of DIRAC output. Please quote if the path include spaces.", dest="file", metavar='"FILE"')
+    parser.add_argument("-i", "--input", type=str, required=True, help="(required) file path of DIRAC output. Please quote if the path include spaces.", dest="input", metavar='"INPUT"')
     parser.add_argument("-o", "--output", type=str, help="Output file name. Default: sum_dirac_dfcoef.out. Please quote if the path include spaces.", dest="output", metavar='"OUTPUT"')
     parser.add_argument(
         "-g",

--- a/src/sum_dirac_dfcoef/args.py
+++ b/src/sum_dirac_dfcoef/args.py
@@ -36,7 +36,7 @@ def parse_args() -> "argparse.Namespace":
         description="Summarize the coefficients from DIRAC output file that *PRIVEC option is used. (c.f. http://www.diracprogram.org/doc/master/manual/analyze/privec.html)"
     )
     parser.add_argument("-i", "--input", type=str, required=True, help="(required) file path of DIRAC output. Please quote if the path include spaces.", dest="input", metavar='"INPUT"')
-    parser.add_argument("-o", "--output", type=str, help="Output file name. Default: sum_dirac_dfcoef.out. Please quote if the path include spaces.", dest="output", metavar='"OUTPUT"')
+    parser.add_argument("-o", "--output", type=str, help="File path of sum_dirac_dfcoef output. Default: sum_dirac_dfcoef.out. Please quote if the path include spaces.", dest="output", metavar='"OUTPUT"')
     parser.add_argument(
         "-g",
         "--for-generator",

--- a/src/sum_dirac_dfcoef/args.py
+++ b/src/sum_dirac_dfcoef/args.py
@@ -35,8 +35,8 @@ def parse_args() -> "argparse.Namespace":
     parser = PrintHelpArgumentParser(
         description="Summarize the coefficients from DIRAC output file that *PRIVEC option is used. (c.f. http://www.diracprogram.org/doc/master/manual/analyze/privec.html)"
     )
-    parser.add_argument("-i", "--input", type=str, required=True, help="(required) file path of DIRAC output", dest="file")
-    parser.add_argument("-o", "--output", type=str, help="Output file name. Default: sum_dirac_dfcoef.out", dest="output")
+    parser.add_argument("-i", "--input", type=str, required=True, help="(required) file path of DIRAC output. Please quote if the path include spaces.", dest="file", metavar='"FILE"')
+    parser.add_argument("-o", "--output", type=str, help="Output file name. Default: sum_dirac_dfcoef.out. Please quote if the path include spaces.", dest="output", metavar='"OUTPUT"')
     parser.add_argument(
         "-g",
         "--for-generator",

--- a/src/sum_dirac_dfcoef/file_writer.py
+++ b/src/sum_dirac_dfcoef/file_writer.py
@@ -72,11 +72,7 @@ class OutputFileWriter:
             output_name = "sum_dirac_dfcoef.out"
             output_path = Path.absolute(Path.cwd() / output_name)
         else:
-            output_name = args.output
-            if Path(output_name).is_absolute():
-                output_path = Path(output_name)
-            else:
-                output_path = Path.absolute(Path.cwd() / output_name)
+            output_path = Path(args.output).expanduser().resolve()
         return output_path
 
 

--- a/src/sum_dirac_dfcoef/file_writer.py
+++ b/src/sum_dirac_dfcoef/file_writer.py
@@ -68,11 +68,17 @@ class OutputFileWriter:
         file.close()
 
     def get_output_path(self) -> Path:
+        import sys
+
         if args.output is None:
             output_name = "sum_dirac_dfcoef.out"
             output_path = Path.absolute(Path.cwd() / output_name)
         else:
             output_path = Path(args.output).expanduser().resolve()
+            if output_path.is_dir():
+                sys.exit(f"ERROR: The path you specified as the sum_dirac_dfcoef output is a directory. Not a file.\
+Please check your -o or --output option is correct.")
+
         return output_path
 
 

--- a/src/sum_dirac_dfcoef/utils.py
+++ b/src/sum_dirac_dfcoef/utils.py
@@ -93,12 +93,10 @@ def delete_dirac_input_comment_out(line: str) -> str:
 def get_dirac_filepath() -> Path:
     from sum_dirac_dfcoef.args import args
 
-    if not args.file:
-        sys.exit("ERROR: DIRAC output file is not given. Please use -f option.")
-    elif not Path(args.file).exists():
-        sys.exit(f"ERROR: DIRAC output file is not found. file={args.file}")
-    path = Path(args.file)
-    return path
+    input_path = Path(args.input).expanduser().resolve()
+    if not input_path.exists():
+        sys.exit(f"ERROR: DIRAC output file is not found. file={input_path}")
+    return input_path
 
 
 def should_write_positronic_results_to_file() -> bool:

--- a/src/sum_dirac_dfcoef/utils.py
+++ b/src/sum_dirac_dfcoef/utils.py
@@ -96,6 +96,9 @@ def get_dirac_filepath() -> Path:
     input_path = Path(args.input).expanduser().resolve()
     if not input_path.exists():
         sys.exit(f"ERROR: DIRAC output file is not found. file={input_path}")
+    elif input_path.is_dir():
+        sys.exit(f"ERROR: The path you specified as the DIRAC output is a directory. Not a file.\
+Please check your -i or --input option is correct.")
     return input_path
 
 


### PR DESCRIPTION
- #111 にあるようにWindows環境の場合ファイルパスに空白文字が含まれることがある
  - 空白文字が含まれる場合必ずクォートしなければならない
  - そこでヘルプメッセージにパスに空白文字があるならクォートするように書くようにしたり、-o OUTPUTを-o "OUTPUT"としてクォートで囲まなければならない場合があることを強調するような表示に変更した
    ```
      -i "INPUT", --input "INPUT"
                        (required) file path of DIRAC output. Please quote if the path include spaces.
      -o "OUTPUT", --output "OUTPUT"
                        File path of sum_dirac_dfcoef output. Default: sum_dirac_dfcoef.out. Please quote if the path include spaces.
    ```
- ファイルパスがファイルでなくディレクトリになっている場合を検知してエラーになるようにした